### PR TITLE
feat(bridge): auto-start sensors on boot

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -218,6 +218,50 @@ Pick based on your threat model and existing infrastructure. Both paths are main
 
 ---
 
+## Sensor auto-start
+
+The bridge auto-starts every available sensor on boot — no need to call `POST /api/sensors/start_all` after a restart. The startup hook spawns a background thread so `uvicorn` is ready immediately; sensors come online a few seconds later as Whisper / BLE / etc. finish initialising.
+
+Per-sensor opt-out (env wins over YAML; default is `on`):
+
+```powershell
+# PowerShell — set before launching the bridge
+$env:HMAN_SENSOR_EEG = 'off'        # disable EEG (e.g. Muse not handy)
+$env:HMAN_SENSOR_AUDIO = 'on'       # explicit on (same as default)
+$env:HMAN_SENSOR_KEYSTROKES = 'off'
+$env:HMAN_SENSOR_SCREEN = 'on'
+```
+
+```bash
+# bash — same idea
+export HMAN_SENSOR_EEG=off
+```
+
+Or, equivalently, drop a YAML file at `~/.hman/sensors.yaml` (uses `HMAN_DATA_DIR` if set):
+
+```yaml
+sensors:
+  audio: on
+  eeg: off          # disabled until Muse is fixed
+  keystrokes: on
+  screen: on
+```
+
+Truthy values: `on`, `true`, `yes`, `1`, `enabled`. Falsy: `off`, `false`, `no`, `0`, `disabled`. Anything else is treated as "no opinion" and falls through to the next layer (env > yaml > default).
+
+Boot logs make the decision visible:
+
+```
+[sensor:audio] auto-started
+[sensor:keystrokes] auto-started
+[sensor:eeg] auto-start disabled by config (env)
+[sensor:screen] not available, skipping auto-start
+```
+
+If a sensor fails to start (e.g. Muse can't be found, mic device disappeared) the bridge keeps running — the failure is recorded in that sensor's `last_error` and surfaced in the Subconscious dashboard. The existing manual `/api/sensors/{name}/start` and `/api/sensors/start_all` endpoints still work for runtime toggling.
+
+---
+
 ## What's not yet prod-ready
 
 Flagging honestly:

--- a/packages/python-bridge/api/server.py
+++ b/packages/python-bridge/api/server.py
@@ -21,6 +21,7 @@ import sys
 import threading
 import time
 from collections import deque
+from contextlib import asynccontextmanager
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from pathlib import Path
@@ -37,7 +38,41 @@ from pydantic import BaseModel
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import core  # noqa: E402
 
-app = FastAPI(title=".HMAN Member Bridge", version="0.1.0")
+
+# ── Lifespan: auto-start sensors on boot ────────────────────────────
+#
+# Issue #21: every bridge restart used to leave all sensors idle until
+# someone hit /api/sensors/start_all. Now we kick start_all ourselves
+# at startup, but in a background thread so uvicorn's "ready" signal
+# doesn't wait on Whisper's first-load (~5s) or the EEG BLE handshake
+# (~20s timeout). The /api/health probe stays responsive throughout.
+#
+# Per-sensor opt-out is honoured via env (HMAN_SENSOR_<NAME>=off) and
+# ~/.hman/sensors.yaml — see config.py.
+
+@asynccontextmanager
+async def lifespan(_app: "FastAPI"):
+    # Import here so a circular-import or missing-sensor-dep can't kill
+    # the whole bridge before we even reach the startup hook.
+    try:
+        import sensors as _s
+        threading.Thread(
+            target=_s.autostart_all,
+            name="hman-sensor-autostart",
+            daemon=True,
+        ).start()
+    except Exception as e:
+        # Last-resort net: a bug in autostart wiring must NEVER block
+        # the bridge from coming up. Voice enrollment / Gate 5 stay
+        # functional even if the subconscious never starts.
+        print(f"[startup] sensor auto-start scheduling failed: {e}")
+        traceback.print_exc()
+    yield
+    # No shutdown work — daemon threads die with the process. Existing
+    # /api/sensors/stop_all is still available for graceful teardown.
+
+
+app = FastAPI(title=".HMAN Member Bridge", version="0.1.0", lifespan=lifespan)
 
 # Allowed origins:
 #   dev (localhost)

--- a/packages/python-bridge/config.py
+++ b/packages/python-bridge/config.py
@@ -1,0 +1,130 @@
+"""Bridge runtime configuration — env vars + optional YAML.
+
+Currently scoped to per-sensor auto-start opt-out, but written so other
+boot-time toggles can reuse the same precedence rules:
+
+  1. Environment variables (always win)
+  2. ~/.hman/sensors.yaml (or HMAN_DATA_DIR/sensors.yaml)
+  3. Default: every available sensor auto-starts
+
+Env-var contract:
+  HMAN_SENSOR_AUDIO=on|off
+  HMAN_SENSOR_EEG=on|off
+  HMAN_SENSOR_KEYSTROKES=on|off
+  HMAN_SENSOR_SCREEN=on|off
+
+Truthy values: on, true, yes, 1, enabled
+Falsy values:  off, false, no, 0, disabled
+
+YAML shape:
+  sensors:
+    audio: on
+    eeg: off          # disabled until Muse is fixed
+    keystrokes: on
+    screen: on
+
+The bridge does not crash on a malformed YAML file — it logs and falls
+through to defaults so a typo can't take the bridge offline.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+# Re-use the same data dir resolution as core.py so HMAN_DATA_DIR works
+# everywhere consistently. Imported lazily to avoid a circular import on
+# module load when core.py is still being initialised.
+_TRUTHY = {"on", "true", "yes", "1", "enabled", "enable"}
+_FALSY = {"off", "false", "no", "0", "disabled", "disable"}
+
+
+def _data_dir() -> Path:
+    env = os.environ.get("HMAN_DATA_DIR")
+    if env:
+        return Path(env).expanduser().resolve()
+    return Path.home() / ".hman"
+
+
+def _parse_bool(raw: object) -> Optional[bool]:
+    """Return True/False for recognised values, None for unrecognised.
+
+    Distinguishing 'unrecognised' from 'False' lets us fall through from
+    env to yaml to default cleanly — a stray ``HMAN_SENSOR_AUDIO=banana``
+    is treated as "no opinion expressed" rather than silently disabling.
+    """
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return None
+    s = str(raw).strip().lower()
+    if not s:
+        return None
+    if s in _TRUTHY:
+        return True
+    if s in _FALSY:
+        return False
+    return None
+
+
+def _load_yaml_sensors() -> dict[str, bool]:
+    """Read ~/.hman/sensors.yaml if present. Returns {name: enabled}.
+
+    Any parse error or missing file → empty dict. Never raises.
+    """
+    path = _data_dir() / "sensors.yaml"
+    if not path.exists():
+        return {}
+    try:
+        import yaml  # pyyaml is already a runtime dep
+    except Exception as e:
+        print(f"[config] sensors.yaml found but pyyaml not importable: {e}")
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as e:
+        print(f"[config] failed to parse {path}: {e} — using defaults")
+        return {}
+
+    sensors_section = data.get("sensors") if isinstance(data, dict) else None
+    if not isinstance(sensors_section, dict):
+        return {}
+
+    out: dict[str, bool] = {}
+    for name, value in sensors_section.items():
+        parsed = _parse_bool(value)
+        if parsed is not None:
+            out[str(name).lower()] = parsed
+    return out
+
+
+def sensor_autostart_enabled(name: str) -> bool:
+    """Should this sensor auto-start on boot?
+
+    Precedence: env > yaml > default(True). Returning True does NOT mean
+    the sensor will actually start — the caller still has to check
+    ``sensor.available()``. This function only encodes member intent.
+    """
+    env_key = f"HMAN_SENSOR_{name.upper()}"
+    env_val = _parse_bool(os.environ.get(env_key))
+    if env_val is not None:
+        return env_val
+
+    yaml_cfg = _load_yaml_sensors()
+    if name.lower() in yaml_cfg:
+        return yaml_cfg[name.lower()]
+
+    return True
+
+
+def sensor_autostart_source(name: str) -> str:
+    """Where the auto-start decision came from. Useful for boot logs.
+
+    Returns one of: 'env', 'yaml', 'default'.
+    """
+    if _parse_bool(os.environ.get(f"HMAN_SENSOR_{name.upper()}")) is not None:
+        return "env"
+    if name.lower() in _load_yaml_sensors():
+        return "yaml"
+    return "default"

--- a/packages/python-bridge/sensors/__init__.py
+++ b/packages/python-bridge/sensors/__init__.py
@@ -7,6 +7,10 @@ Order here is the display order in the dashboard.
 """
 from __future__ import annotations
 
+import sys
+import traceback
+from pathlib import Path
+
 from .audio import AudioSensor
 from .keystrokes import KeystrokesSensor
 from .screen import ScreenSensor
@@ -36,3 +40,76 @@ def all_sensors():
 
 def names() -> list[str]:
     return list(_ensure().keys())
+
+
+def autostart_all() -> list[dict]:
+    """Auto-start every sensor that's available *and* enabled by config.
+
+    Logs one line per sensor in the same shape the issue asks for:
+      [sensor:audio] auto-started
+      [sensor:eeg]   auto-start disabled by config
+      [sensor:eeg]   not available (bleak missing)
+      [sensor:audio] failed to start: <error>
+
+    Failures NEVER propagate — if a sensor's start() throws, we capture
+    the message in last_error and keep going. The bridge process must
+    not crash because one sensor misbehaved.
+
+    Returns the list of post-start status dicts so callers can log/test.
+    """
+    # Lazy import — avoids any chance of circular import via core/server.
+    # config.py lives one directory up; we add the parent (the python-bridge
+    # root) to sys.path for the same reason api/server.py does.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import config as _config  # noqa: E402
+
+    results: list[dict] = []
+    for sensor in all_sensors():
+        name = sensor.name
+        enabled = _config.sensor_autostart_enabled(name)
+        source = _config.sensor_autostart_source(name)
+
+        if not enabled:
+            print(f"[sensor:{name}] auto-start disabled by config ({source})")
+            results.append(sensor.status())
+            continue
+
+        try:
+            available = sensor.available()
+        except Exception as e:
+            sensor.last_error = f"available() raised: {type(e).__name__}: {e}"
+            print(f"[sensor:{name}] availability check failed: {e}")
+            results.append(sensor.status())
+            continue
+
+        if not available:
+            # Not an error — just nothing to start (e.g. EEG with no Muse,
+            # keystrokes/screen on non-Windows). Surface in last_error so
+            # the dashboard explains why it's idle.
+            sensor.last_error = "hardware/OS preconditions not met (available=False)"
+            print(f"[sensor:{name}] not available, skipping auto-start")
+            results.append(sensor.status())
+            continue
+
+        try:
+            sensor.start()
+        except Exception as e:
+            # Never let a single sensor crash the bridge. _safe_loop
+            # already swallows in-thread errors; this catches synchronous
+            # failures inside start() itself (e.g. thread spawn errors).
+            sensor.last_error = f"auto-start failed: {type(e).__name__}: {e}"
+            print(f"[sensor:{name}] failed to start: {e}")
+            traceback.print_exc()
+            results.append(sensor.status())
+            continue
+
+        if sensor.running:
+            print(f"[sensor:{name}] auto-started")
+        else:
+            # start() returns silently if already running or unavailable;
+            # if we get here with running=False something quietly refused.
+            print(f"[sensor:{name}] start() returned but sensor not running")
+
+        results.append(sensor.status())
+
+    return results


### PR DESCRIPTION
Fixes #21.

After every bridge restart, all four sensors used to come up `running: false` and have to be kicked manually via `POST /api/sensors/start_all` — silent capture outage every reboot. This change wires a FastAPI lifespan hook that auto-starts every available sensor in a background thread, so uvicorn's ready signal fires immediately while Whisper / BLE / model loads happen in parallel.

## What changed

- **New `packages/python-bridge/config.py`** — reads `HMAN_SENSOR_AUDIO|EEG|KEYSTROKES|SCREEN=on|off` env vars, falls back to `~/.hman/sensors.yaml` (or `$HMAN_DATA_DIR/sensors.yaml`), defaults to `on`. Env wins over YAML. Malformed YAML logs and falls through rather than crashing.
- **`sensors/autostart_all()`** — iterates the registry, honours config, captures any sensor's start failure in `last_error` so a misbehaving sensor (e.g. EEG with no Muse) can't take the bridge down. Logs one line per sensor in the issue's spec format: `[sensor:audio] auto-started`, `[sensor:eeg] auto-start disabled by config (env)`, etc.
- **`api/server.py`** — adds an `asynccontextmanager` lifespan that schedules `autostart_all` on a daemon thread. No new blocking work on the request path; the existing `/api/sensors/{name}/{start,stop,status}` + `start_all`/`stop_all` endpoints are untouched.
- **`DEPLOYMENT.md`** — documents the env vars, YAML shape, truthy/falsy values, and what the boot log looks like.

## Test plan

- [ ] Restart bridge with no env vars → all four available sensors auto-start, boot log shows `[sensor:<name>] auto-started` per sensor
- [ ] `HMAN_SENSOR_EEG=off python api/server.py` → EEG stays idle, log says `auto-start disabled by config (env)`
- [ ] Drop `~/.hman/sensors.yaml` with `eeg: off` → same behaviour
- [ ] Set both env and YAML to conflicting values → env wins
- [ ] Stop Muse and start with EEG enabled → bridge stays up, EEG `last_error` populated, other sensors unaffected
- [ ] `/api/sensors/start_all` and per-sensor `start`/`stop` still work at runtime
- [ ] uvicorn becomes ready in under a second (sensor init shouldn't block startup)

In-process integration test exercised four scenarios (success, unavailable, start raised, env opt-out) with stub sensors — boot lines and `last_error` values matched the spec in all four.

Heavy deps unchanged. `pyyaml` was already in `requirements.txt`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>