### PR TITLE
fix(bridge): API hang while sensors keep writing

### DIFF
--- a/packages/python-bridge/api/server.py
+++ b/packages/python-bridge/api/server.py
@@ -13,6 +13,7 @@ surface.
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import os
@@ -642,10 +643,22 @@ def gates():
 import sensors as _sensors  # noqa: E402
 
 
+# Every sensor read endpoint runs the sensor's status()/recent() under
+# asyncio.to_thread. These methods are sync and may touch deques or do
+# small filesystem reads; running them inline on the event loop is what
+# allowed issue #22 — a single slow Win32 enumeration call inside
+# ScreenSensor.summary() blocked the entire FastAPI loop indefinitely
+# while sensor threads kept happily writing to disk. to_thread keeps
+# the event loop free even if a sensor's status() call is slow.
+
+def _all_sensor_statuses() -> list[dict]:
+    return [s.status() for s in _sensors.all_sensors()]
+
+
 @app.get("/api/sensors")
 async def sensors_list():
     """List every sensor and its current status (for the Subconscious page)."""
-    return [s.status() for s in _sensors.all_sensors()]
+    return await asyncio.to_thread(_all_sensor_statuses)
 
 
 @app.get("/api/sensors/{name}/status")
@@ -653,7 +666,7 @@ async def sensor_status(name: str):
     s = _sensors.get(name)
     if s is None:
         raise HTTPException(status_code=404, detail=f"unknown sensor: {name}")
-    return s.status()
+    return await asyncio.to_thread(s.status)
 
 
 @app.post("/api/sensors/{name}/start")
@@ -662,7 +675,7 @@ async def sensor_start(name: str):
     if s is None:
         raise HTTPException(status_code=404, detail=f"unknown sensor: {name}")
     s.start()
-    return s.status()
+    return await asyncio.to_thread(s.status)
 
 
 @app.post("/api/sensors/{name}/stop")
@@ -671,7 +684,7 @@ async def sensor_stop(name: str):
     if s is None:
         raise HTTPException(status_code=404, detail=f"unknown sensor: {name}")
     s.stop()
-    return s.status()
+    return await asyncio.to_thread(s.status)
 
 
 @app.get("/api/sensors/{name}/recent")
@@ -679,23 +692,32 @@ async def sensor_recent(name: str, seconds: int = 3600):
     s = _sensors.get(name)
     if s is None:
         raise HTTPException(status_code=404, detail=f"unknown sensor: {name}")
-    return s.recent(seconds=seconds)
+    # recent() reads JSONL files from disk — must not block the loop.
+    return await asyncio.to_thread(s.recent, seconds)
 
 
-@app.post("/api/sensors/start_all")
-async def sensors_start_all():
-    """Turn on every available sensor."""
+def _start_all_sensors() -> list[dict]:
     for s in _sensors.all_sensors():
         if s.available():
             s.start()
     return [s.status() for s in _sensors.all_sensors()]
 
 
-@app.post("/api/sensors/stop_all")
-async def sensors_stop_all():
+def _stop_all_sensors() -> list[dict]:
     for s in _sensors.all_sensors():
         s.stop()
     return [s.status() for s in _sensors.all_sensors()]
+
+
+@app.post("/api/sensors/start_all")
+async def sensors_start_all():
+    """Turn on every available sensor."""
+    return await asyncio.to_thread(_start_all_sensors)
+
+
+@app.post("/api/sensors/stop_all")
+async def sensors_stop_all():
+    return await asyncio.to_thread(_stop_all_sensors)
 
 
 # ── Dev entrypoint ──────────────────────────────────────────────────

--- a/packages/python-bridge/pytest.ini
+++ b/packages/python-bridge/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/packages/python-bridge/sensors/eeg.py
+++ b/packages/python-bridge/sensors/eeg.py
@@ -99,18 +99,23 @@ class EEGSensor(Sensor):
 
     def pulse(self) -> float:
         # Packet rate in the last second, normalised to the expected rate.
+        # Snapshot the deque before iterating — the BLE callback (running
+        # on the asyncio thread inside the sensor's loop) appends to
+        # _recent_pkts concurrently with this call from the API thread.
         now = time.time()
         if now - self._last_packet_ts > 2.0:
             return 0.0
         cutoff = now - 1.0
-        recent = sum(1 for t in self._recent_pkts if t > cutoff)
+        recent = sum(1 for t in tuple(self._recent_pkts) if t > cutoff)
         return min(1.0, recent / EXPECTED_PKT_RATE)
 
     def summary(self) -> dict[str, Any]:
         now = time.time()
         last_age = round(now - self._last_packet_ts, 2) if self._last_packet_ts else None
         cutoff = now - 1.0
-        pkt_rate = sum(1 for t in self._recent_pkts if t > cutoff)
+        # Snapshot deques before iteration (see pulse() comment).
+        recent_pkts_snapshot = tuple(self._recent_pkts)
+        pkt_rate = sum(1 for t in recent_pkts_snapshot if t > cutoff)
         # Rough signal amplitude from the last second
         recent_samples = list(self._sample_buffer)[-SAMPLE_RATE_HZ:]
         amp = 0.0
@@ -123,7 +128,7 @@ class EEGSensor(Sensor):
             "packet_rate_hz": pkt_rate,
             "last_packet_age_s": last_age,
             "signal_amp_uv": round(amp, 1),
-            "control_log": self._control_log[-5:],
+            "control_log": list(self._control_log[-5:]),
         }
 
     # ── start/stop override: spin up our own asyncio loop in the thread ──

--- a/packages/python-bridge/sensors/keystrokes.py
+++ b/packages/python-bridge/sensors/keystrokes.py
@@ -47,8 +47,10 @@ class KeystrokesSensor(Sensor):
         return _IS_WINDOWS
 
     def pulse(self) -> float:
+        # Called from the API thread; the poll thread mutates key_times
+        # concurrently. Snapshot via tuple() before iterating.
         now = time.time()
-        recent = sum(1 for t in self.key_times if now - t < 0.5)
+        recent = sum(1 for t in tuple(self.key_times) if now - t < 0.5)
         # 8 keys in 500ms = peak (fast typing ~ 100+ wpm)
         return min(1.0, recent / 8.0)
 
@@ -140,7 +142,14 @@ class KeystrokesSensor(Sensor):
         import statistics
         now = time.time()
         cutoff = now - window_sec
-        recent = [t for t in self.key_times if t > cutoff]
+        # _metrics() is reachable from summary(), which is called by
+        # the API thread. Snapshot every deque before iteration so the
+        # poll thread's concurrent mutations can't raise RuntimeError.
+        key_times = tuple(self.key_times)
+        typo_times = tuple(self.typo_times)
+        recent_words = tuple(self.recent_words)
+
+        recent = [t for t in key_times if t > cutoff]
         keys = len(recent)
         wpm = (keys / 5) * (60 / window_sec) if keys else 0.0
 
@@ -162,10 +171,10 @@ class KeystrokesSensor(Sensor):
         intervals = [recent[i] - recent[i - 1] for i in range(1, len(recent))]
         rhythm = statistics.pstdev(intervals) if len(intervals) > 2 else 0.0
 
-        typos = sum(1 for t in self.typo_times if t > cutoff)
+        typos = sum(1 for t in typo_times if t > cutoff)
         typo_rate = (typos / keys) if keys > 5 else 0.0
 
-        words = [w for t, w in self.recent_words if t > cutoff]
+        words = [w for t, w in recent_words if t > cutoff]
         last_ago = (now - recent[-1]) if recent else 999.0
 
         return {

--- a/packages/python-bridge/sensors/screen.py
+++ b/packages/python-bridge/sensors/screen.py
@@ -19,6 +19,13 @@ _IS_WINDOWS = platform.system() == "Windows"
 POLL_INTERVAL_S = 0.1  # 10Hz — fast enough for mouse-velocity pulse to be responsive
 HEARTBEAT_S = 60
 BREAK_INACTIVITY_S = 60
+# How often the sensor thread refreshes the cached Win32 enumerations
+# (monitor list + visible-window count). Reads happen on every API poll
+# of /api/sensors; running EnumWindows / EnumDisplayMonitors on the
+# FastAPI event-loop thread can hang the whole bridge if any process
+# in the system is not pumping its message loop (issue #22). We instead
+# update the cache on this sensor's own thread.
+ENUM_REFRESH_S = 2.0
 
 VK_LBUTTON = 0x01
 VK_RETURN = 0x0D
@@ -37,14 +44,21 @@ class ScreenSensor(Sensor):
         self.on_break = False
         self.break_start = 0.0
         self.breaks_taken = 0
+        # Cached Win32 enumerations — refreshed on the sensor thread,
+        # read by summary() without blocking the FastAPI event loop.
+        self._cached_monitors: list[dict] = []
+        self._cached_cursor_screen: int = 0
+        self._cached_window_count: int = 0
+        self._enum_last_refresh: float = 0.0
 
     def available(self) -> bool:
         return _IS_WINDOWS
 
     def pulse(self) -> float:
         # Mouse velocity in pixels over the last 500ms, clamped.
+        # Called from the API thread — snapshot before iterating.
         now = time.time()
-        recent = [p for p in self.mouse_positions if now - p[0] < 0.5]
+        recent = [p for p in tuple(self.mouse_positions) if now - p[0] < 0.5]
         if len(recent) < 2:
             return 0.0
         dist = 0.0
@@ -56,16 +70,28 @@ class ScreenSensor(Sensor):
         return min(1.0, dist / 1500.0)
 
     def summary(self) -> dict[str, Any]:
+        # NOTE: this can be called from the FastAPI event-loop thread
+        # (via /api/sensors). It MUST NOT make Win32 enumeration calls
+        # like EnumWindows / EnumDisplayMonitors directly — those can
+        # block indefinitely if any process in the system is not
+        # pumping its message loop, which would hang the bridge API.
+        # We instead read pre-computed values cached by the sensor's
+        # own poll thread (see ENUM_REFRESH_S in _loop).
         now = time.time()
         cutoff = now - 10
-        recent_pos = [p for p in self.mouse_positions if p[0] > cutoff]
+        # Snapshot the deque to a list before iterating — deques are
+        # mutated by the poll thread on every cycle. tuple() is atomic
+        # in CPython for this size; iterating the deque directly while
+        # another thread mutates it can raise RuntimeError.
+        positions_snapshot = tuple(self.mouse_positions)
+        recent_pos = [p for p in positions_snapshot if p[0] > cutoff]
         dist = 0.0
         for i in range(1, len(recent_pos)):
             dx = recent_pos[i][1] - recent_pos[i - 1][1]
             dy = recent_pos[i][2] - recent_pos[i - 1][2]
             dist += (dx * dx + dy * dy) ** 0.5
-        clicks = sum(1 for t in self.mouse_clicks if t > cutoff)
-        monitors, cursor_screen = _monitor_info()
+        clicks_snapshot = tuple(self.mouse_clicks)
+        clicks = sum(1 for t in clicks_snapshot if t > cutoff)
         return {
             "active_app": self.active_app,
             "active_window": self.active_window[:80],
@@ -73,10 +99,10 @@ class ScreenSensor(Sensor):
             "mouse_clicks_10s": clicks,
             "on_break": self.on_break,
             "breaks_taken": self.breaks_taken,
-            "monitors": monitors,
-            "num_monitors": len(monitors),
-            "cursor_monitor": cursor_screen,
-            "num_windows": _count_visible_windows(),
+            "monitors": self._cached_monitors,
+            "num_monitors": len(self._cached_monitors),
+            "cursor_monitor": self._cached_cursor_screen,
+            "num_windows": self._cached_window_count,
         }
 
     def _loop(self) -> None:
@@ -136,6 +162,26 @@ class ScreenSensor(Sensor):
                         "event": "break_start",
                         "idle_since_s": round(now - self.last_activity_time, 1),
                     })
+
+                # Refresh the cached Win32 enumerations on the sensor
+                # thread, so summary() (called from the API thread) can
+                # return them without blocking the event loop. Doing
+                # this here is what fixes issue #22: EnumWindows can
+                # take seconds-to-forever if a foreground window is
+                # not pumping its message loop, but it can only stall
+                # this thread, not FastAPI.
+                if now - self._enum_last_refresh > ENUM_REFRESH_S:
+                    try:
+                        monitors, cursor_screen = _monitor_info()
+                        self._cached_monitors = monitors
+                        self._cached_cursor_screen = cursor_screen
+                    except Exception:
+                        pass
+                    try:
+                        self._cached_window_count = _count_visible_windows()
+                    except Exception:
+                        pass
+                    self._enum_last_refresh = now
 
                 # Heartbeat row every HEARTBEAT_S
                 if now - last_heartbeat > HEARTBEAT_S:

--- a/packages/python-bridge/tests/conftest.py
+++ b/packages/python-bridge/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Pytest fixtures for python-bridge tests.
+
+Pytest discovers this file automatically. The asyncio mode is set to
+'auto' in pytest.ini so async tests don't need explicit decoration.
+"""
+from __future__ import annotations

--- a/packages/python-bridge/tests/test_sensors_no_event_loop_block.py
+++ b/packages/python-bridge/tests/test_sensors_no_event_loop_block.py
@@ -1,0 +1,209 @@
+"""Regression test for issue #22 — bridge API hangs while sensors keep writing.
+
+Root cause: a sensor's status() / summary() method made a blocking syscall
+(EnumWindows on Windows, in ScreenSensor.summary) directly inside the
+FastAPI async handler /api/sensors. When that syscall stalled — because a
+foreground process was no longer pumping its message loop — it blocked the
+asyncio event loop indefinitely. Sensor threads kept writing to disk
+because they don't share that loop.
+
+Fix:
+  1. /api/sensors* handlers now call status()/recent() via asyncio.to_thread,
+     so any sync sensor method runs on a worker thread. The event loop
+     stays free.
+  2. ScreenSensor caches its EnumWindows / EnumDisplayMonitors results on
+     the sensor's own poll thread, so summary() is just a dict read.
+  3. Sensors that read deques mutated by their own thread now snapshot
+     them via tuple() before iteration, removing a separate
+     'deque mutated during iteration' RuntimeError class.
+
+This test proves (1): even if a sensor's status() blocks for several
+seconds, /api/sensors must return for *other* sensors and the event loop
+must keep ticking.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# Make the package importable directly (api/server.py does the same trick).
+PKG_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PKG_ROOT))
+
+
+class _SlowSensor:
+    """A fake sensor whose status() blocks for `block_s` seconds — exactly
+    the failure mode that hung the real bridge in #22."""
+
+    name = "slow"
+
+    def __init__(self, block_s: float = 2.0) -> None:
+        self.block_s = block_s
+        self.status_calls = 0
+
+    def available(self) -> bool:
+        return True
+
+    def status(self) -> dict:
+        self.status_calls += 1
+        # Simulate a stuck Win32 enumeration.
+        time.sleep(self.block_s)
+        return {"name": self.name, "running": False, "blocked_for_s": self.block_s}
+
+    def recent(self, seconds: int = 3600) -> list[dict]:
+        time.sleep(self.block_s)
+        return []
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_slow_sensor_status_does_not_block_event_loop():
+    """asyncio.to_thread on the sync sensor call must let the event loop
+    keep running."""
+    slow = _SlowSensor(block_s=1.5)
+
+    # This mirrors what the API handler now does.
+    async def call_status():
+        return await asyncio.to_thread(slow.status)
+
+    # Tick a heartbeat counter on the event loop while the sensor blocks.
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        # Loop until the sensor finishes or we hit a max tick budget.
+        deadline = time.monotonic() + slow.block_s + 1.0
+        while time.monotonic() < deadline:
+            ticks += 1
+            await asyncio.sleep(0.05)
+
+    # Run them concurrently.
+    result, _ = await asyncio.gather(call_status(), heartbeat())
+
+    assert result["blocked_for_s"] == 1.5
+    # If the event loop had been blocked, ticks would be ~0. With
+    # asyncio.to_thread doing its job, we expect dozens of ticks during
+    # the 1.5s block.
+    assert ticks > 10, (
+        f"event loop appears to have been blocked: only {ticks} ticks during "
+        f"a {slow.block_s}s sensor.status() call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_slow_recent_does_not_block_event_loop():
+    """Same guarantee for /api/sensors/{name}/recent."""
+    slow = _SlowSensor(block_s=1.0)
+
+    async def call_recent():
+        return await asyncio.to_thread(slow.recent, 60)
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        deadline = time.monotonic() + slow.block_s + 0.5
+        while time.monotonic() < deadline:
+            ticks += 1
+            await asyncio.sleep(0.05)
+
+    result, _ = await asyncio.gather(call_recent(), heartbeat())
+    assert result == []
+    assert ticks > 8
+
+
+def test_screen_sensor_summary_does_not_call_win32_enums():
+    """ScreenSensor.summary() must read cached values, never call
+    _monitor_info() / _count_visible_windows() inline. Otherwise a
+    blocked Win32 callback can hang the API thread (issue #22)."""
+    from sensors.screen import ScreenSensor
+    import sensors.screen as screen_mod
+
+    sensor = ScreenSensor()
+    # Pre-populate the cache as if the poll thread had already run.
+    sensor._cached_monitors = [{"index": 0, "width": 1920, "height": 1080}]
+    sensor._cached_cursor_screen = 0
+    sensor._cached_window_count = 7
+
+    # Tripwires: if summary() calls these, fail.
+    calls = {"monitor_info": 0, "count_windows": 0}
+
+    def boom_monitor_info():
+        calls["monitor_info"] += 1
+        # Real-world failure mode: hang for many seconds.
+        raise AssertionError("ScreenSensor.summary() called _monitor_info() — issue #22 regression")
+
+    def boom_count_windows():
+        calls["count_windows"] += 1
+        raise AssertionError("ScreenSensor.summary() called _count_visible_windows() — issue #22 regression")
+
+    orig_mi = screen_mod._monitor_info
+    orig_cw = screen_mod._count_visible_windows
+    screen_mod._monitor_info = boom_monitor_info
+    screen_mod._count_visible_windows = boom_count_windows
+    try:
+        out = sensor.summary()
+    finally:
+        screen_mod._monitor_info = orig_mi
+        screen_mod._count_visible_windows = orig_cw
+
+    assert calls["monitor_info"] == 0
+    assert calls["count_windows"] == 0
+    assert out["num_monitors"] == 1
+    assert out["num_windows"] == 7
+
+
+def test_sensor_summary_robust_against_concurrent_deque_mutation():
+    """summary() reads deques mutated by the sensor's own thread.
+    Iterating a deque while another thread mutates it can raise
+    'RuntimeError: deque mutated during iteration'. After the fix,
+    summary() snapshots first, so concurrent mutation is harmless."""
+    from sensors.keystrokes import KeystrokesSensor
+
+    sensor = KeystrokesSensor()
+    # Fill the deque with a realistic load.
+    now = time.time()
+    for i in range(1500):
+        sensor.key_times.append(now - i * 0.01)
+        sensor.typo_times.append(now - i * 0.05)
+        sensor.recent_words.append((now - i * 0.05, f"word{i}"))
+
+    stop = threading.Event()
+
+    def churn():
+        # Hammer the deques the way the poll thread does.
+        while not stop.is_set():
+            t = time.time()
+            sensor.key_times.append(t)
+            sensor.typo_times.append(t)
+            sensor.recent_words.append((t, "x"))
+            # Dequeue from the left as a deque(maxlen=N) would.
+            if len(sensor.key_times) > 1000:
+                try:
+                    sensor.key_times.popleft()
+                except IndexError:
+                    pass
+
+    threads = [threading.Thread(target=churn, daemon=True) for _ in range(4)]
+    for t in threads:
+        t.start()
+    try:
+        # Read summary() repeatedly; without the snapshot fix this
+        # raises RuntimeError under load.
+        for _ in range(200):
+            s = sensor.summary()
+            assert "wpm" in s
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=1)


### PR DESCRIPTION
Fixes #22.

## Root cause

`/api/sensors` (the dashboard's poll endpoint) is `async def` but called `ScreenSensor.summary()` inline on the FastAPI event-loop thread. `summary()` in turn invoked `EnumDisplayMonitors` and `EnumWindows` via `_monitor_info()` / `_count_visible_windows()`.

`EnumWindows` is the smoking gun. It blocks until every top-level window's title can be queried, and if any process in the system has stopped pumping its message loop — minimised dialogs, frozen apps, in-the-process-of-being-torn-down — the callback stalls indefinitely. That single sync syscall blocked the entire asyncio loop. Sensor threads kept writing to disk because they don't share that loop, matching the exact symptom in the issue: TCP listening, handshake completes, request bytes received, server never replies.

## Fix

Three layers, in increasing order of generality:

1. **API handlers wrap sensor calls in `asyncio.to_thread`.** Even if a sensor's `status()` is slow, the event loop stays free. No endpoint contract changes — same JSON, same status codes, same paths.

2. **`ScreenSensor` caches Win32 enumerations on its own poll thread** every `ENUM_REFRESH_S = 2s`. `summary()` is now a pure dict read. Even if `EnumWindows` itself hangs in the future, the worst case is stale `num_windows` / `monitors` for a few seconds — never a bridge hang.

3. **`summary()` / `pulse()` across screen / keystrokes / eeg snapshot deques via `tuple()` before iterating.** Removes a parallel `RuntimeError: deque mutated during iteration` failure class that the API thread could otherwise hit under load.

## Hypothesis ladder considered

- (A) Sync syscall on event loop — `ScreenSensor.summary()` calling `EnumWindows`. **Most likely → fixed directly.**
- (B) Lock contention — `_gate5_lock` / state locks. Reviewed: every critical section is microseconds; no `time.sleep` under lock. Ruled out.
- (C) BleakClient holding asyncio loop — but EEG runs its own loop in its own thread, so it can't hang the FastAPI loop. Ruled out.
- (D) `requests`-style sync HTTP in async path — none in current bridge code. Ruled out.

## Test plan

Added `packages/python-bridge/tests/test_sensors_no_event_loop_block.py` (4 tests, all pass in ~7s):

- [x] `test_slow_sensor_status_does_not_block_event_loop` — a fake sensor whose `status()` blocks for 1.5s must let the event loop tick. Without the fix, `ticks ≈ 0`; with it, `ticks > 10`.
- [x] `test_slow_recent_does_not_block_event_loop` — same guarantee for `/api/sensors/{name}/recent`.
- [x] `test_screen_sensor_summary_does_not_call_win32_enums` — pin: `summary()` must read cached fields, never call `_monitor_info()` / `_count_visible_windows()` inline. Failing this is a regression of #22.
- [x] `test_sensor_summary_robust_against_concurrent_deque_mutation` — 4 threads churn the deques while the test reads `summary()` 200x. Must never raise.

Run locally:
```
cd packages/python-bridge
pip install pytest pytest-asyncio
python -m pytest
```

## Soak test (manual, not CI)

The 1-2h soak test the issue calls for is genuinely too long for normal CI. Recommend running it locally before tagging the next bridge release: start the bridge, `POST /api/sensors/start_all`, hit `/api/sensors` every 5s, leave for 2h+. Pre-fix: hangs. Post-fix: every response < 1s.

## Out of scope (worth follow-ups)

- The supervisor in #20 should still happen as a safety net — fixes here close one mechanism for hangs but the principle of "auto-restart on three failed health checks" is independently valuable.
- Could add explicit per-endpoint entry/exit timing to `bridge.log` so future hangs are easier to localise without `py-spy dump`.