### PR TITLE
feat(ios): app skeleton — SwiftPM, SwiftUI shell, bridge client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,10 @@ jobs:
           cd packages/bridge-relay-listener
           dotnet restore
           dotnet build -c Release --no-restore
+
+  ios-build:
+    name: iOS app skeleton — swift build
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - run: cd apps/ios && swift build

--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -1,0 +1,56 @@
+// swift-tools-version: 5.9
+//
+// HMAN iOS app — Swift Package Manager manifest.
+//
+// We deliberately ship as a SwiftPM package rather than an .xcodeproj so the
+// repo stays git-friendly and CI can validate via `swift build` on macos-14
+// without xcodebuild gymnastics. Future Wave 2 PRs may layer an .xcodeproj
+// on top for richer asset / signing config — that's out of scope here.
+//
+// Deployment target: iOS 17.0. SwiftUI surface compiles cleanly on this
+// floor; iOS 18 / 26 features can be `#available`-gated as they arrive.
+
+import PackageDescription
+
+let package = Package(
+    name: "HMAN",
+    platforms: [
+        .iOS(.v17),
+    ],
+    products: [
+        .library(
+            name: "HMAN",
+            targets: ["HMAN"]
+        ),
+    ],
+    dependencies: [
+        // libsodium for PACT signing (Wave 2 #15) and any future
+        // E2EE work. Pinned to a known-good range; bump in a follow-up.
+        .package(
+            url: "https://github.com/jedisct1/swift-sodium",
+            from: "0.9.1"
+        ),
+        // Keychain access for bridge bearer tokens, voice biometric
+        // enrolment material (#18), and PACT private keys (#15).
+        .package(
+            url: "https://github.com/kishikawakatsumi/KeychainAccess",
+            from: "4.2.2"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "HMAN",
+            dependencies: [
+                .product(name: "Sodium", package: "swift-sodium"),
+                .product(name: "Clibsodium", package: "swift-sodium"),
+                .product(name: "KeychainAccess", package: "KeychainAccess"),
+            ],
+            path: "Sources/HMAN"
+        ),
+        .testTarget(
+            name: "HMANTests",
+            dependencies: ["HMAN"],
+            path: "Tests/HMANTests"
+        ),
+    ]
+)

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,0 +1,91 @@
+# HMAN iOS app
+
+Native iOS client for HMAN. Currently a **chassis** — SwiftUI shell, typed bridge client, and Codable ports of `packages/shared/src/types/`. Real features land in Wave 2 sub-issues:
+
+- #14 — AirPods motion telemetry
+- #15 — PACT signing (libsodium)
+- #16 — HealthKit ingest
+- #17 — APNs push for access requests
+- #18 — voice-biometric (Gate 5) on device
+
+## Layout
+
+```
+apps/ios/
+├── Package.swift                       SwiftPM manifest, iOS 17+ floor
+├── Sources/HMAN/
+│   ├── HMANApp.swift                   @main SwiftUI entry
+│   ├── ContentView.swift               TabView shell
+│   ├── Bridge/HMANBridgeClient.swift   typed FastAPI wrapper, BridgeError
+│   ├── Models/                         Codable ports of shared TS types
+│   └── Views/                          placeholder routes (Welcome, ...)
+└── Tests/HMANTests/
+    └── HMANBridgeClientTests.swift     URL-construction + decoder tests
+```
+
+## Requirements
+
+- **iOS 17.0+** deployment target
+- **Xcode 15+** to open / run on simulator or device
+- **Swift 5.9+** (for SPM `swift-tools-version: 5.9`)
+
+## Build from CLI
+
+```bash
+cd apps/ios
+swift build
+swift test
+```
+
+This is what CI runs on `macos-14`. No `xcodebuild` invocation needed at this stage — the SwiftPM target compiles cleanly without a project / scheme.
+
+## Open in Xcode
+
+```bash
+open Package.swift
+```
+
+Xcode resolves the SPM dependencies (`swift-sodium`, `KeychainAccess`) on first open. Pick an iOS Simulator scheme (e.g. iPhone 15 Pro, iOS 17.5) and hit Run.
+
+## Run on simulator
+
+1. Open `apps/ios/Package.swift` in Xcode 15+.
+2. Wait for "Resolving Package Graph" to finish.
+3. Select the **HMAN** scheme.
+4. Choose any iOS 17 / 18 simulator.
+5. **Cmd-R**. The tab bar shell launches.
+
+## Run on a physical device
+
+Skeleton-stage: not yet wired for device builds. To do it manually you need an Apple developer account configured in Xcode and a generated app target.
+
+A future PR (after the chassis is in `main`) will add either:
+
+- An `.xcodeproj` alongside `Package.swift` so signing config and Info.plist entitlements travel in the repo, or
+- A scripted `xcodebuild`-driven flow that injects a member-supplied team ID at build time.
+
+For now: open `Package.swift` in Xcode, select the **HMAN** scheme, choose your physical device, and let Xcode prompt for code-signing setup. iCloud / push / HealthKit entitlements arrive with their respective Wave 2 issues — the skeleton has none.
+
+## Bridge configuration
+
+`HMANBridgeClient` defaults to `http://127.0.0.1:8765`, which matches the FastAPI bridge in `packages/python-bridge`. Bearer tokens are stored in the iOS Keychain via `KeychainAccess`. The token is set during onboarding (Wave 2) — for now the skeleton exposes:
+
+```swift
+let client = HMANBridgeClient()
+try client.setBearerToken("...")
+let health = try await client.health()
+let gates = try await client.gatesStatus()
+```
+
+## Dependencies
+
+Pulled via SwiftPM (declared in `Package.swift`):
+
+- [`swift-sodium`](https://github.com/jedisct1/swift-sodium) — libsodium bindings, used by Wave 2 #15 PACT signing.
+- [`KeychainAccess`](https://github.com/kishikawakatsumi/KeychainAccess) — Keychain wrapper for bridge tokens, biometric material, PACT keys.
+
+HTTP uses `URLSession` directly — no Alamofire — to keep the dependency surface small.
+
+## CI
+
+`.github/workflows/ci.yml` includes an `ios-build` job that runs `swift build` on `macos-14`. No `xcodebuild` step yet; that arrives once we have an `.xcodeproj` for device builds.

--- a/apps/ios/Sources/HMAN/Bridge/HMANBridgeClient.swift
+++ b/apps/ios/Sources/HMAN/Bridge/HMANBridgeClient.swift
@@ -1,0 +1,221 @@
+// HMANBridgeClient.swift — typed wrapper around the FastAPI bridge surface.
+//
+// The bridge runs on the member's own device (default http://127.0.0.1:8765
+// in development; reachable over an attested tunnel in production). All
+// calls are bearer-token authenticated. The token lives in the iOS Keychain
+// (KeychainAccess wrapper) so reinstall / app-relaunch keeps the trust
+// relationship.
+//
+// JSON convention: snake_case on the wire (matches `packages/shared/src/types`
+// when those are serialised by FastAPI), ISO-8601 dates. The shared
+// `JSONDecoder` and `JSONEncoder` factories below enforce that.
+//
+// Wave 2 sub-issues will extend this client:
+//   #14 — motion telemetry POST
+//   #15 — PACT signature submission
+//   #16 — HealthKit ingest
+//   #17 — APNs device-token registration
+//   #18 — voice-biometric verify
+// Stubbed methods are kept minimal here: health, gates, enrollment kickoff.
+
+import Foundation
+import KeychainAccess
+
+public enum BridgeError: Error, Sendable, Equatable {
+    /// Bridge URL was malformed.
+    case invalidURL
+    /// Underlying URLSession transport failure (network, TLS, host unreachable).
+    case transport(String)
+    /// Non-2xx HTTP status. `detail` is the bridge's `{"detail": "..."}` body
+    /// when present, mirroring FastAPI's error shape.
+    case http(status: Int, detail: String?)
+    /// JSON decode/encode failure on a 2xx response or a request body.
+    case decoding(String)
+    /// Bearer token not configured. Caller should drive the user through
+    /// onboarding to mint and store one.
+    case missingToken
+}
+
+public protocol BridgeTokenStore: Sendable {
+    func token() -> String?
+    func setToken(_ token: String?) throws
+}
+
+/// Default Keychain-backed token store. Service id is namespaced so a
+/// future multi-account flow can swap it without colliding.
+public struct KeychainTokenStore: BridgeTokenStore {
+    private let keychain: Keychain
+    private let key: String
+
+    public init(service: String = "ai.hman.bridge", key: String = "bearer-token") {
+        self.keychain = Keychain(service: service)
+        self.key = key
+    }
+
+    public func token() -> String? {
+        try? keychain.get(key)
+    }
+
+    public func setToken(_ token: String?) throws {
+        if let token, !token.isEmpty {
+            try keychain.set(token, key: key)
+        } else {
+            try keychain.remove(key)
+        }
+    }
+}
+
+public final class HMANBridgeClient: @unchecked Sendable {
+    public static let defaultBaseURL = URL(string: "http://127.0.0.1:8765")!
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let tokenStore: BridgeTokenStore
+
+    public init(
+        baseURL: URL = HMANBridgeClient.defaultBaseURL,
+        session: URLSession = .shared,
+        tokenStore: BridgeTokenStore = KeychainTokenStore()
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.tokenStore = tokenStore
+    }
+
+    // ── Public surface ──────────────────────────────────────────────
+
+    /// `GET /api/health`. Doesn't require auth in dev mode but we still
+    /// attach the token if present — the bridge accepts it either way.
+    public func health() async throws -> BridgeHealth {
+        try await get("/api/health", requiresAuth: false)
+    }
+
+    /// `GET /api/gates`. Aggregate Gate 1..5 status.
+    public func gatesStatus() async throws -> GatesResponse {
+        try await get("/api/gates")
+    }
+
+    /// `POST /api/enrollment/session` — kicks off voice enrolment for #18.
+    public func enrollmentBegin(passphrase: String, memberId: String = "member") async throws -> EnrollmentSession {
+        struct Body: Encodable {
+            let passphrase: String
+            let memberId: String
+
+            enum CodingKeys: String, CodingKey {
+                case passphrase
+                case memberId = "member_id"
+            }
+        }
+        return try await post("/api/enrollment/session", body: Body(passphrase: passphrase, memberId: memberId))
+    }
+
+    // ── Token management (delegates to the configured store) ────────
+
+    public func setBearerToken(_ token: String?) throws {
+        try tokenStore.setToken(token)
+    }
+
+    public func currentBearerToken() -> String? {
+        tokenStore.token()
+    }
+
+    // ── URL construction (testable in isolation) ────────────────────
+
+    /// Build a request URL by appending `path` (which must start with `/`)
+    /// to the configured base URL. Exposed for tests.
+    public func url(forPath path: String) throws -> URL {
+        guard path.hasPrefix("/"), var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw BridgeError.invalidURL
+        }
+        // Append path without dropping the base path (none today, but
+        // future tunnel deployments might mount the bridge under a prefix).
+        components.path = (components.path == "/" ? "" : components.path) + path
+        guard let url = components.url else {
+            throw BridgeError.invalidURL
+        }
+        return url
+    }
+
+    // ── Internals ───────────────────────────────────────────────────
+
+    private func get<Response: Decodable>(_ path: String, requiresAuth: Bool = true) async throws -> Response {
+        var request = URLRequest(url: try url(forPath: path))
+        request.httpMethod = "GET"
+        try attachAuth(&request, required: requiresAuth)
+        return try await send(request)
+    }
+
+    private func post<Body: Encodable, Response: Decodable>(
+        _ path: String,
+        body: Body,
+        requiresAuth: Bool = true
+    ) async throws -> Response {
+        var request = URLRequest(url: try url(forPath: path))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        try attachAuth(&request, required: requiresAuth)
+        do {
+            request.httpBody = try Self.encoder.encode(body)
+        } catch {
+            throw BridgeError.decoding("encode: \(error)")
+        }
+        return try await send(request)
+    }
+
+    private func attachAuth(_ request: inout URLRequest, required: Bool) throws {
+        if let token = tokenStore.token(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        } else if required {
+            throw BridgeError.missingToken
+        }
+    }
+
+    private func send<Response: Decodable>(_ request: URLRequest) async throws -> Response {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw BridgeError.transport(String(describing: error))
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw BridgeError.transport("non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let detail = Self.decodeErrorDetail(data)
+            throw BridgeError.http(status: http.statusCode, detail: detail)
+        }
+        do {
+            return try Self.decoder.decode(Response.self, from: data)
+        } catch {
+            throw BridgeError.decoding(String(describing: error))
+        }
+    }
+
+    private static func decodeErrorDetail(_ data: Data) -> String? {
+        // FastAPI returns {"detail": "..."} on HTTPException. Decode loosely.
+        struct Body: Decodable { let detail: String? }
+        return (try? JSONDecoder().decode(Body.self, from: data))?.detail
+    }
+
+    // ── Shared coders ───────────────────────────────────────────────
+    //
+    // FastAPI emits snake_case JSON keys and ISO-8601 timestamps. Our
+    // Swift models declare CodingKeys explicitly where the mapping is
+    // non-obvious; for any model that doesn't, .convertFromSnakeCase
+    // falls through. ISO-8601 covers `Date` round-trip.
+
+    public static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    public static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.keyEncodingStrategy = .convertToSnakeCase
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+}

--- a/apps/ios/Sources/HMAN/ContentView.swift
+++ b/apps/ios/Sources/HMAN/ContentView.swift
@@ -1,0 +1,50 @@
+// ContentView.swift — root tab bar.
+//
+// Mirrors the navigation chassis of the React member-app dashboard so a
+// member can move between Welcome, Onboarding, Dashboard, Gates, Memory,
+// and Audit without surprise. All views are placeholders — features
+// land in Wave 2 sub-issues.
+
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        TabView {
+            WelcomeView()
+                .tabItem {
+                    Label("Welcome", systemImage: "hand.wave")
+                }
+
+            OnboardingView()
+                .tabItem {
+                    Label("Onboard", systemImage: "person.badge.plus")
+                }
+
+            DashboardView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+
+            GatesView()
+                .tabItem {
+                    Label("Gates", systemImage: "lock.shield")
+                }
+
+            MemoryView()
+                .tabItem {
+                    Label("Memory", systemImage: "brain")
+                }
+
+            AuditView()
+                .tabItem {
+                    Label("Audit", systemImage: "doc.text.magnifyingglass")
+                }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/apps/ios/Sources/HMAN/HMANApp.swift
+++ b/apps/ios/Sources/HMAN/HMANApp.swift
@@ -1,0 +1,18 @@
+// HMANApp.swift — SwiftUI entry point.
+//
+// The app is a thin shell: a tab bar wrapping the placeholder views that
+// mirror the React member-app routes. Real logic comes in Wave 2 sub-issues
+// (#14 motion, #15 PACT, #16 HealthKit, #17 APNs, #18 voice biometric).
+
+import SwiftUI
+
+@main
+public struct HMANApp: App {
+    public init() {}
+
+    public var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/apps/ios/Sources/HMAN/Models/AccessRequest.swift
+++ b/apps/ios/Sources/HMAN/Models/AccessRequest.swift
@@ -1,0 +1,110 @@
+// AccessRequest.swift — port of packages/shared/src/types/access.ts.
+//
+// AI/agent access requests, the response a member sends back, and the
+// delegation flow for granting scoped access to another HMAN member.
+
+import Foundation
+
+public struct AccessRequest: Codable, Sendable, Hashable {
+    public let id: String
+    public let requester: RequesterInfo
+    public let resource: ResourceInfo
+    public let purpose: String
+    public let timestamp: Date
+    public let status: AccessRequestStatus
+    public let expiresAt: Date
+    public let approvalExpiresAt: Date?
+    public let response: AccessResponse?
+}
+
+public enum AccessRequestStatus: String, Codable, Sendable {
+    case pending, approved, denied, expired, cancelled
+}
+
+public struct RequesterInfo: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case aiModel = "ai_model"
+        case bot, delegate, application
+    }
+
+    public let id: String
+    public let type: Kind
+    public let name: String
+    public let metadata: JSONValue?
+}
+
+public struct ResourceInfo: Codable, Sendable, Hashable {
+    public let uri: String
+    public let name: String
+    public let vaultId: String
+    public let permissionLevel: PermissionLevel
+    public let description: String?
+}
+
+public struct AccessResponse: Codable, Sendable, Hashable {
+    public enum Decision: String, Codable, Sendable {
+        case allowOnce = "allow_once"
+        case allowTimed = "allow_timed"
+        case allowSession = "allow_session"
+        case deny
+        case denyAlways = "deny_always"
+    }
+
+    public let decision: Decision
+    public let respondedBy: String
+    public let respondedAt: Date
+    public let expiresAt: Date?
+    public let reason: String?
+}
+
+// ── Delegation ──────────────────────────────────────────────────────
+
+public struct Delegation: Codable, Sendable, Hashable {
+    public let id: String
+    public let grantor: String
+    public let delegate: DelegateInfo
+    public let vaultIds: [String]
+    public let permissions: [DelegatedPermission]
+    public let conditions: [DelegationCondition]?
+    public let createdAt: Date
+    public let expiresAt: Date
+    public let status: DelegationStatus
+    public let acceptedAt: Date?
+    public let revokedAt: Date?
+    public let revocationReason: String?
+}
+
+public enum DelegationStatus: String, Codable, Sendable {
+    case pending, active, expired, revoked
+}
+
+public struct DelegateInfo: Codable, Sendable, Hashable {
+    public let id: String
+    public let displayName: String
+    public let handle: String
+    public let publicKey: String
+}
+
+public struct DelegatedPermission: Codable, Sendable, Hashable {
+    public let resourcePattern: String
+    public let actions: [DelegatedAction]
+    public let maxApprovalLevel: PermissionLevel
+}
+
+public enum DelegatedAction: String, Codable, Sendable {
+    case view
+    case approvePayment = "approve_payment"
+    case respondToRequest = "respond_to_request"
+    case export
+}
+
+public struct DelegationCondition: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case amountLimit = "amount_limit"
+        case timeWindow = "time_window"
+        case requireNotification = "require_notification"
+    }
+
+    public let type: Kind
+    public let params: JSONValue
+}

--- a/apps/ios/Sources/HMAN/Models/AuditEntry.swift
+++ b/apps/ios/Sources/HMAN/Models/AuditEntry.swift
@@ -1,0 +1,147 @@
+// AuditEntry.swift — port of packages/shared/src/types/audit.ts.
+//
+// All access is logged locally with a hash chain. This file ports the
+// log-entry shape, query filters, and summary aggregate.
+
+import Foundation
+
+public struct AuditLogEntry: Codable, Sendable, Hashable {
+    public let id: String
+    public let timestamp: Date
+    public let action: AuditAction
+    public let actor: AuditActor
+    public let resource: AuditResource
+    public let outcome: AuditOutcome
+    public let metadata: JSONValue?
+    public let previousEntryHash: String?
+    public let entryHash: String
+}
+
+public enum AuditAction: String, Codable, Sendable, CaseIterable {
+    case accessRequest = "access_request"
+    case accessGranted = "access_granted"
+    case accessDenied = "access_denied"
+    case dataRead = "data_read"
+    case dataWrite = "data_write"
+    case dataDelete = "data_delete"
+    case vaultUnlock = "vault_unlock"
+    case vaultLock = "vault_lock"
+    case delegationCreated = "delegation_created"
+    case delegationAccepted = "delegation_accepted"
+    case delegationRevoked = "delegation_revoked"
+    case delegationExpired = "delegation_expired"
+    case paymentRequested = "payment_requested"
+    case paymentApproved = "payment_approved"
+    case paymentDenied = "payment_denied"
+    case paymentExecuted = "payment_executed"
+    case exportRequested = "export_requested"
+    case exportCompleted = "export_completed"
+    case permissionChanged = "permission_changed"
+    case keyRotation = "key_rotation"
+}
+
+public struct AuditActor: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case user
+        case aiModel = "ai_model"
+        case delegate, bot, system
+    }
+
+    public let type: Kind
+    public let id: String
+    public let name: String
+    public let modelId: String?
+    public let deviceInfo: String?
+}
+
+public struct AuditResource: Codable, Sendable, Hashable {
+    public let uri: String
+    public let vaultId: String
+    public let itemId: String?
+    public let permissionLevel: PermissionLevel
+    public let description: String?
+}
+
+public struct AuditOutcome: Codable, Sendable, Hashable {
+    public enum ApprovalMethod: String, Codable, Sendable {
+        case auto
+        case userApproved = "user_approved"
+        case delegateApproved = "delegate_approved"
+        case preAuthorized = "pre_authorized"
+    }
+
+    public let success: Bool
+    public let failureReason: String?
+    public let approvalMethod: ApprovalMethod?
+    public let accessDuration: String?
+}
+
+public struct AuditQuery: Codable, Sendable, Hashable {
+    public enum SortOrder: String, Codable, Sendable {
+        case asc, desc
+    }
+
+    public let startTime: Date?
+    public let endTime: Date?
+    public let actions: [AuditAction]?
+    public let actorId: String?
+    public let actorType: AuditActor.Kind?
+    public let vaultId: String?
+    public let resourceUri: String?
+    public let successOnly: Bool?
+    public let failureOnly: Bool?
+    public let limit: Int?
+    public let offset: Int?
+    public let sortOrder: SortOrder?
+
+    public init(
+        startTime: Date? = nil,
+        endTime: Date? = nil,
+        actions: [AuditAction]? = nil,
+        actorId: String? = nil,
+        actorType: AuditActor.Kind? = nil,
+        vaultId: String? = nil,
+        resourceUri: String? = nil,
+        successOnly: Bool? = nil,
+        failureOnly: Bool? = nil,
+        limit: Int? = nil,
+        offset: Int? = nil,
+        sortOrder: SortOrder? = nil
+    ) {
+        self.startTime = startTime
+        self.endTime = endTime
+        self.actions = actions
+        self.actorId = actorId
+        self.actorType = actorType
+        self.vaultId = vaultId
+        self.resourceUri = resourceUri
+        self.successOnly = successOnly
+        self.failureOnly = failureOnly
+        self.limit = limit
+        self.offset = offset
+        self.sortOrder = sortOrder
+    }
+}
+
+public struct AuditSummary: Codable, Sendable, Hashable {
+    public struct ResourceCount: Codable, Sendable, Hashable {
+        public let uri: String
+        public let accessCount: Int
+    }
+
+    public struct ActorCount: Codable, Sendable, Hashable {
+        public let id: String
+        public let name: String
+        public let actionCount: Int
+    }
+
+    public let startTime: Date
+    public let endTime: Date
+    public let totalActions: Int
+    public let actionCounts: [String: Int]
+    public let actorTypeCounts: [String: Int]
+    public let successCount: Int
+    public let failureCount: Int
+    public let topResources: [ResourceCount]
+    public let topActors: [ActorCount]
+}

--- a/apps/ios/Sources/HMAN/Models/Gates.swift
+++ b/apps/ios/Sources/HMAN/Models/Gates.swift
@@ -1,0 +1,80 @@
+// Gates.swift — Gate 1..5 status types.
+//
+// Mirrors the FastAPI bridge `/api/gates` response (see
+// packages/python-bridge/api/server.py:572). The TS dashboard uses an
+// inline shape; we define explicit Codable structs here so iOS calls
+// through `HMANBridgeClient.gatesStatus()` get a typed payload.
+//
+// Gate 5 (Voice-Bound) has its own status endpoint with richer detail —
+// modelled separately as `Gate5Status`.
+
+import Foundation
+
+public struct GateStatus: Codable, Sendable, Hashable, Identifiable {
+    /// Stable identity for SwiftUI lists. `name` is unique across the five gates.
+    public var id: String { name }
+
+    /// "Light Bulb Moment", "Member Control", "Extension of Thinking",
+    /// "Reactive and Non-Invasive", "Voice-Bound to the Member".
+    public let name: String
+    public let passing: Bool
+    public let detail: String
+}
+
+public struct GatesResponse: Codable, Sendable, Hashable {
+    public let memberId: String
+    public let gates: [GateStatus]
+    public let lastActivation: String?
+    public let rejectionsLastHour: Int
+
+    enum CodingKeys: String, CodingKey {
+        case memberId = "member_id"
+        case gates
+        case lastActivation = "last_activation"
+        case rejectionsLastHour = "rejections_last_hour"
+    }
+}
+
+/// Detailed Gate 5 status — voice-bound runtime state.
+public struct Gate5Status: Codable, Sendable, Hashable {
+    public struct Event: Codable, Sendable, Hashable {
+        public let timestamp: String
+        public let accepted: Bool
+        public let similarity: Double?
+        public let reason: String?
+    }
+
+    public let enrolled: Bool
+    public let armed: Bool
+    public let armedAt: String?
+    public let threshold: Double
+    public let accepts: Int
+    public let rejects: Int
+    public let lastActivation: String?
+    public let recentEvents: [Event]
+}
+
+/// Health probe shape — `GET /api/health`.
+public struct BridgeHealth: Codable, Sendable, Hashable {
+    public let ok: Bool
+    public let version: String
+    public let gpu: Bool
+    public let enrolled: Bool
+}
+
+/// Enrollment session response — `POST /api/enrollment/session`.
+public struct EnrollmentSession: Codable, Sendable, Hashable {
+    public let sessionId: String
+    public let memberId: String
+    public let prompts: [String]
+    public let currentIndex: Int
+    public let total: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case memberId = "member_id"
+        case prompts
+        case currentIndex = "current_index"
+        case total
+    }
+}

--- a/apps/ios/Sources/HMAN/Models/JSONValue.swift
+++ b/apps/ios/Sources/HMAN/Models/JSONValue.swift
@@ -1,0 +1,59 @@
+// JSONValue.swift — minimal type-erased JSON for free-form payloads.
+//
+// Several ported types (Permission.autoApproveConditions[i].params,
+// RequesterInfo.metadata, DelegationCondition.params) are
+// `Record<string, unknown>` in TypeScript. Swift Codable doesn't have a
+// first-class equivalent, so we model it as a recursive enum that round-
+// trips through any JSONEncoder/Decoder.
+//
+// Wave 2 consumers can switch on `type` and decode the params into the
+// matching strongly-typed condition struct (TimeWindowCondition, etc.).
+
+import Foundation
+
+public enum JSONValue: Codable, Sendable, Hashable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let v = try? container.decode(Bool.self) {
+            self = .bool(v)
+        } else if let v = try? container.decode(Int.self) {
+            self = .int(v)
+        } else if let v = try? container.decode(Double.self) {
+            self = .double(v)
+        } else if let v = try? container.decode(String.self) {
+            self = .string(v)
+        } else if let v = try? container.decode([JSONValue].self) {
+            self = .array(v)
+        } else if let v = try? container.decode([String: JSONValue].self) {
+            self = .object(v)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let v): try container.encode(v)
+        case .int(let v): try container.encode(v)
+        case .double(let v): try container.encode(v)
+        case .string(let v): try container.encode(v)
+        case .array(let v): try container.encode(v)
+        case .object(let v): try container.encode(v)
+        }
+    }
+}

--- a/apps/ios/Sources/HMAN/Models/Permission.swift
+++ b/apps/ios/Sources/HMAN/Models/Permission.swift
@@ -1,0 +1,89 @@
+// Permission.swift — port of packages/shared/src/types/permissions.ts.
+//
+// HMAN Permission Levels (the "Gate" system):
+//   0 Open     — auto-shared with any connected AI
+//   1 Standard — shared with logging; user notified post-hoc
+//   2 Gated    — requires tap-to-approve; push notification
+//   3 Locked   — never shared via MCP; manual copy only
+//
+// `PermissionLevel` is an Int-backed enum to match the TS numeric enum.
+// JSON encoding therefore round-trips as a number, which is what the
+// FastAPI bridge produces.
+
+import Foundation
+
+public enum PermissionLevel: Int, Codable, Sendable, CaseIterable {
+    case open = 0
+    case standard = 1
+    case gated = 2
+    case locked = 3
+}
+
+public struct Permission: Codable, Sendable, Hashable {
+    public let level: PermissionLevel
+    public let description: String
+    public let delegatable: Bool
+    public let autoApproveConditions: [AutoApproveCondition]?
+
+    public init(
+        level: PermissionLevel,
+        description: String,
+        delegatable: Bool,
+        autoApproveConditions: [AutoApproveCondition]? = nil
+    ) {
+        self.level = level
+        self.description = description
+        self.delegatable = delegatable
+        self.autoApproveConditions = autoApproveConditions
+    }
+}
+
+/// Discriminated union mirroring the TS condition variants.
+/// We keep the `params` as a free-form JSON dict here because the placeholder
+/// app never inspects them — the real consumers (Wave 2) will switch on
+/// `type` and decode into the matching strongly-typed condition struct below.
+public struct AutoApproveCondition: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case timeWindow = "time_window"
+        case amountLimit = "amount_limit"
+        case requesterWhitelist = "requester_whitelist"
+        case frequencyLimit = "frequency_limit"
+    }
+
+    public let type: Kind
+    public let params: JSONValue
+
+    public init(type: Kind, params: JSONValue) {
+        self.type = type
+        self.params = params
+    }
+}
+
+public struct TimeWindowCondition: Codable, Sendable, Hashable {
+    public let startHour: Int
+    public let endHour: Int
+    public let daysOfWeek: [Int]
+    public let timezone: String
+}
+
+public struct AmountLimitCondition: Codable, Sendable, Hashable {
+    public enum Period: String, Codable, Sendable {
+        case perRequest = "per_request"
+        case daily, weekly, monthly
+    }
+    public let maxAmount: Double
+    public let currency: String
+    public let period: Period
+}
+
+public struct RequesterWhitelistCondition: Codable, Sendable, Hashable {
+    public let allowedRequesters: [String]
+}
+
+public struct FrequencyLimitCondition: Codable, Sendable, Hashable {
+    public enum Period: String, Codable, Sendable {
+        case hour, day, week
+    }
+    public let maxRequests: Int
+    public let period: Period
+}

--- a/apps/ios/Sources/HMAN/Models/Vault.swift
+++ b/apps/ios/Sources/HMAN/Models/Vault.swift
@@ -1,0 +1,222 @@
+// Vault.swift — port of packages/shared/src/types/vault.ts.
+//
+// Encrypted data compartments. The metadata travels as JSON; the
+// `encryptedContent` blob stays opaque to the app shell — Wave 2 #15 wires
+// up libsodium decryption.
+
+import Foundation
+
+public enum VaultType: String, Codable, Sendable, CaseIterable {
+    case identity, finance, health, diary, calendar, secrets, custom
+}
+
+public struct Vault: Codable, Sendable, Hashable {
+    public let id: String
+    public let type: VaultType
+    public let name: String
+    public let description: String?
+    public let defaultPermissionLevel: PermissionLevel
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let isUnlocked: Bool
+    public let encryptionMetadata: VaultEncryptionMetadata
+}
+
+public struct VaultEncryptionMetadata: Codable, Sendable, Hashable {
+    public enum Algorithm: String, Codable, Sendable {
+        case argon2id
+    }
+
+    public let algorithm: Algorithm
+    public let salt: String
+    public let memoryCost: Int
+    public let timeCost: Int
+    public let parallelism: Int
+    public let encryptedVaultKey: String
+    public let vaultKeyNonce: String
+}
+
+public struct VaultItem: Codable, Sendable, Hashable {
+    public let id: String
+    public let vaultId: String
+    public let itemType: String
+    public let title: String
+    public let permission: Permission?
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let encryptedContent: String
+    public let contentNonce: String
+    public let tags: [String]?
+    public let resourceUri: String
+}
+
+/// Generic decrypted view over any item content shape.
+public struct DecryptedVaultItem<Content: Codable & Sendable>: Codable, Sendable {
+    public let id: String
+    public let vaultId: String
+    public let itemType: String
+    public let title: String
+    public let permission: Permission?
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let tags: [String]?
+    public let resourceUri: String
+    public let content: Content
+}
+
+// ── Item content shapes ─────────────────────────────────────────────
+
+public struct TransactionContent: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case income, expense, transfer
+    }
+
+    public let type: Kind
+    public let amount: Double
+    public let currency: String
+    public let category: String
+    public let subcategory: String?
+    public let merchant: String?
+    public let date: String  // ISO 8601
+    public let notes: String?
+    public let paymentMethod: String?
+    public let recurring: Bool?
+}
+
+public struct BillContent: Codable, Sendable, Hashable {
+    public enum Status: String, Codable, Sendable {
+        case pending, paid, overdue
+    }
+
+    public struct PaymentRecord: Codable, Sendable, Hashable {
+        public let date: String
+        public let amount: Double
+    }
+
+    public let provider: String
+    public let accountNumber: String?
+    public let amount: Double
+    public let currency: String
+    public let dueDate: String
+    public let category: String
+    public let status: Status
+    public let invoiceNumber: String?
+    public let paymentHistory: [PaymentRecord]?
+}
+
+public struct HealthRecordContent: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case consultation, prescription
+        case testResult = "test_result"
+        case vaccination, procedure
+    }
+
+    public let type: Kind
+    public let provider: String
+    public let date: String
+    public let summary: String
+    public let details: String?
+    public let attachments: [String]?
+}
+
+public struct IdentityDocumentContent: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case passport
+        case driversLicense = "drivers_license"
+        case birthCertificate = "birth_certificate"
+        case taxFileNumber = "tax_file_number"
+        case medicare, other
+    }
+
+    public let type: Kind
+    public let documentNumber: String?
+    public let issuedBy: String?
+    public let issueDate: String?
+    public let expiryDate: String?
+    public let notes: String?
+}
+
+public enum MessagingPlatform: String, Codable, Sendable {
+    case signal, whatsapp, telegram, imessage, sms, email, matrix, discord, slack
+}
+
+public struct ContactMethod: Codable, Sendable, Hashable {
+    public let platform: MessagingPlatform
+    public let identifier: String
+    public let isPrimary: Bool?
+    public let isVerified: Bool?
+    public let label: String?
+}
+
+public struct ProfileContent: Codable, Sendable, Hashable {
+    public struct Address: Codable, Sendable, Hashable {
+        public let street: String?
+        public let city: String?
+        public let state: String?
+        public let postalCode: String?
+        public let country: String?
+    }
+
+    public let displayName: String
+    public let email: String?
+    public let phone: String?
+    public let dateOfBirth: String?
+    public let address: Address?
+    public let languagePreference: String
+    public let timezone: String
+    public let contactMethods: [ContactMethod]?
+    public let avatarUri: String?
+    public let bio: String?
+}
+
+public struct DiaryEntryContent: Codable, Sendable, Hashable {
+    public let date: String
+    public let mood: String?
+    public let content: String
+    public let tags: [String]?
+}
+
+public struct CalendarEventContent: Codable, Sendable, Hashable {
+    public struct Reminder: Codable, Sendable, Hashable {
+        public enum Kind: String, Codable, Sendable {
+            case notification, email
+        }
+        public let type: Kind
+        public let minutesBefore: Int
+    }
+
+    public struct Recurrence: Codable, Sendable, Hashable {
+        public enum Frequency: String, Codable, Sendable {
+            case daily, weekly, monthly, yearly
+        }
+        public let frequency: Frequency
+        public let interval: Int
+        public let until: String?
+    }
+
+    public let title: String
+    public let description: String?
+    public let startTime: String
+    public let endTime: String
+    public let location: String?
+    public let attendees: [String]?
+    public let reminders: [Reminder]?
+    public let recurring: Recurrence?
+}
+
+public struct SecretContent: Codable, Sendable, Hashable {
+    public enum Kind: String, Codable, Sendable {
+        case password
+        case apiKey = "api_key"
+        case privateKey = "private_key"
+        case recoveryPhrase = "recovery_phrase"
+        case other
+    }
+
+    public let type: Kind
+    public let value: String
+    public let username: String?
+    public let url: String?
+    public let notes: String?
+    public let lastRotated: String?
+}

--- a/apps/ios/Sources/HMAN/Views/AuditView.swift
+++ b/apps/ios/Sources/HMAN/Views/AuditView.swift
@@ -1,0 +1,31 @@
+// AuditView.swift — audit log placeholder.
+//
+// Real implementation tails the bridge's audit endpoint and renders
+// `AuditLogEntry` rows with hash-chain badges.
+
+import SwiftUI
+
+public struct AuditView: View {
+    public init() {}
+
+    public var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Text("Audit log — coming soon")
+                        .foregroundStyle(.secondary)
+                }
+                Section("Filters") {
+                    Label("By actor", systemImage: "person")
+                    Label("By action", systemImage: "list.bullet")
+                    Label("By time", systemImage: "clock")
+                }
+            }
+            .navigationTitle("Audit")
+        }
+    }
+}
+
+#Preview {
+    AuditView()
+}

--- a/apps/ios/Sources/HMAN/Views/DashboardView.swift
+++ b/apps/ios/Sources/HMAN/Views/DashboardView.swift
@@ -1,0 +1,30 @@
+// DashboardView.swift — home tab placeholder.
+//
+// Will surface live bridge health, gate state, and pending access requests
+// once Wave 2 #17 (APNs) and the real bridge integration land.
+
+import SwiftUI
+
+public struct DashboardView: View {
+    public init() {}
+
+    public var body: some View {
+        NavigationStack {
+            List {
+                Section("Status") {
+                    Label("Bridge: unknown", systemImage: "circle.dashed")
+                    Label("Gates: not loaded", systemImage: "circle.dashed")
+                }
+                Section("Pending requests") {
+                    Text("None — coming soon")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Dashboard")
+        }
+    }
+}
+
+#Preview {
+    DashboardView()
+}

--- a/apps/ios/Sources/HMAN/Views/GatesView.swift
+++ b/apps/ios/Sources/HMAN/Views/GatesView.swift
@@ -1,0 +1,38 @@
+// GatesView.swift — Gate 1..5 status placeholder.
+//
+// Mirrors the React member-app /gates route. Real content fetches via
+// `HMANBridgeClient.gatesStatus()`; the chassis just lists the names.
+
+import SwiftUI
+
+public struct GatesView: View {
+    public init() {}
+
+    private static let placeholderGates: [String] = [
+        "Light Bulb Moment",
+        "Member Control",
+        "Extension of Thinking",
+        "Reactive and Non-Invasive",
+        "Voice-Bound to the Member",
+    ]
+
+    public var body: some View {
+        NavigationStack {
+            List(Self.placeholderGates, id: \.self) { name in
+                HStack {
+                    Image(systemName: "lock.shield")
+                        .foregroundStyle(.secondary)
+                    Text(name)
+                    Spacer()
+                    Text("—")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Gates")
+        }
+    }
+}
+
+#Preview {
+    GatesView()
+}

--- a/apps/ios/Sources/HMAN/Views/MemoryView.swift
+++ b/apps/ios/Sources/HMAN/Views/MemoryView.swift
@@ -1,0 +1,33 @@
+// MemoryView.swift — subconscious / memory placeholder.
+//
+// Will eventually show recent ambient transcript, topic timeline, and
+// knowledge-graph slices once the iOS sensors story is in flight.
+
+import SwiftUI
+
+public struct MemoryView: View {
+    public init() {}
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                Image(systemName: "brain")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.tint)
+                Text("Memory — coming soon")
+                    .font(.headline)
+                Text("Topic timeline, recent transcript, and knowledge graph land in later Wave 2 issues.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            .padding()
+            .navigationTitle("Memory")
+        }
+    }
+}
+
+#Preview {
+    MemoryView()
+}

--- a/apps/ios/Sources/HMAN/Views/OnboardingView.swift
+++ b/apps/ios/Sources/HMAN/Views/OnboardingView.swift
@@ -1,0 +1,33 @@
+// OnboardingView.swift — placeholder for the bridge-pair + voice-enrol flow.
+//
+// Wave 2 #18 (voice biometric) drives the real content here.
+
+import SwiftUI
+
+public struct OnboardingView: View {
+    public init() {}
+
+    public var body: some View {
+        NavigationStack {
+            List {
+                Section("Bridge") {
+                    Label("Pair with this device", systemImage: "link")
+                    Label("Set bearer token", systemImage: "key")
+                }
+                Section("Voice biometric (Gate 5)") {
+                    Label("Enrol your voice", systemImage: "waveform")
+                }
+                Section {
+                    Text("Onboarding flow coming soon — chassis only for now.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Onboarding")
+        }
+    }
+}
+
+#Preview {
+    OnboardingView()
+}

--- a/apps/ios/Sources/HMAN/Views/WelcomeView.swift
+++ b/apps/ios/Sources/HMAN/Views/WelcomeView.swift
@@ -1,0 +1,34 @@
+// WelcomeView.swift — first-run placeholder.
+//
+// Real welcome flow lands in a Wave 2 sub-issue. For now the chassis just
+// proves the navigation works.
+
+import SwiftUI
+
+public struct WelcomeView: View {
+    public init() {}
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Image(systemName: "hand.wave.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.tint)
+                Text("Welcome to HMAN")
+                    .font(.title)
+                    .bold()
+                Text("Your subconscious in your pocket — coming soon.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            .padding()
+            .navigationTitle("Welcome")
+        }
+    }
+}
+
+#Preview {
+    WelcomeView()
+}

--- a/apps/ios/Tests/HMANTests/HMANBridgeClientTests.swift
+++ b/apps/ios/Tests/HMANTests/HMANBridgeClientTests.swift
@@ -1,0 +1,66 @@
+// HMANBridgeClientTests.swift — placeholder URL-construction tests.
+//
+// Wave 2 work will add transport-level tests with a stubbed URLProtocol.
+// For the skeleton we just lock down the basics: URL building, token-
+// store wiring, and JSON coder configuration.
+
+import XCTest
+@testable import HMAN
+
+final class HMANBridgeClientTests: XCTestCase {
+    func testHealthURLAppendsPath() throws {
+        let client = HMANBridgeClient(
+            baseURL: URL(string: "http://127.0.0.1:8765")!,
+            tokenStore: InMemoryTokenStore()
+        )
+        let url = try client.url(forPath: "/api/health")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:8765/api/health")
+    }
+
+    func testGatesURLAppendsPath() throws {
+        let client = HMANBridgeClient(
+            baseURL: URL(string: "https://bridge.example.com")!,
+            tokenStore: InMemoryTokenStore()
+        )
+        let url = try client.url(forPath: "/api/gates")
+        XCTAssertEqual(url.absoluteString, "https://bridge.example.com/api/gates")
+    }
+
+    func testRejectsPathWithoutLeadingSlash() {
+        let client = HMANBridgeClient(
+            baseURL: URL(string: "http://127.0.0.1:8765")!,
+            tokenStore: InMemoryTokenStore()
+        )
+        XCTAssertThrowsError(try client.url(forPath: "api/health")) { error in
+            XCTAssertEqual(error as? BridgeError, .invalidURL)
+        }
+    }
+
+    func testTokenRoundtrip() throws {
+        let store = InMemoryTokenStore()
+        let client = HMANBridgeClient(tokenStore: store)
+        XCTAssertNil(client.currentBearerToken())
+        try client.setBearerToken("hunter2")
+        XCTAssertEqual(client.currentBearerToken(), "hunter2")
+        try client.setBearerToken(nil)
+        XCTAssertNil(client.currentBearerToken())
+    }
+
+    func testDecoderUsesSnakeCaseAndISO8601() throws {
+        // Round-trip a simple snake_case payload with an ISO-8601 timestamp.
+        let json = #"""
+        {"member_id": "member", "gates": [], "last_activation": null, "rejections_last_hour": 0}
+        """#.data(using: .utf8)!
+        let response = try HMANBridgeClient.decoder.decode(GatesResponse.self, from: json)
+        XCTAssertEqual(response.memberId, "member")
+        XCTAssertEqual(response.rejectionsLastHour, 0)
+        XCTAssertTrue(response.gates.isEmpty)
+    }
+}
+
+// In-memory token store so tests don't touch the real Keychain.
+private final class InMemoryTokenStore: BridgeTokenStore, @unchecked Sendable {
+    private var stored: String?
+    func token() -> String? { stored }
+    func setToken(_ token: String?) throws { stored = token }
+}


### PR DESCRIPTION
Fixes #13.

Foundation work for the native iOS phone client. Chassis only — every Wave 2 sub-issue (#14 motion, #15 PACT, #16 HealthKit, #17 APNs, #18 voice biometric) builds on top.

## Summary

- **SwiftPM package** at `apps/ios/`, iOS 17+, no `.xcodeproj` (git-friendly, CI-friendly, easy to layer Xcode project on later for device signing).
- **SwiftUI tab shell** mirroring the React member-app routes: Welcome, Onboarding, Dashboard, Gates, Memory, Audit. All placeholders.
- **Typed bridge client** (`HMANBridgeClient.swift`) — URLSession-based wrapper around the FastAPI bridge with snake_case + ISO-8601 JSON coders, `BridgeError` mirroring FastAPI's `{"detail": "..."}` shape, `BridgeTokenStore` protocol with a Keychain-backed default. Stub methods: `health()`, `gatesStatus()`, `enrollmentBegin(passphrase:memberId:)`. No Alamofire — URLSession only to keep deps small.
- **Codable Swift ports** of `packages/shared/src/types/`:
  - `permissions.ts` → `Permission.swift` (`PermissionLevel`, `Permission`, `AutoApproveCondition` plus `TimeWindow`/`AmountLimit`/`RequesterWhitelist`/`FrequencyLimit` variants)
  - `vault.ts` → `Vault.swift` (`Vault`, `VaultItem`, `DecryptedVaultItem<T>`, `Transaction`/`Bill`/`HealthRecord`/`IdentityDocument`/`Profile`/`DiaryEntry`/`CalendarEvent`/`Secret` content shapes, `MessagingPlatform`, `ContactMethod`)
  - `access.ts` → `AccessRequest.swift` (`AccessRequest`, `RequesterInfo`, `ResourceInfo`, `AccessResponse`, `Delegation` tree)
  - `audit.ts` → `AuditEntry.swift` (`AuditLogEntry`, `AuditAction`, `AuditActor`/`Resource`/`Outcome`, `AuditQuery`, `AuditSummary`)
  - bridge gates → `Gates.swift` (`GateStatus`, `GatesResponse`, `Gate5Status`, `BridgeHealth`, `EnrollmentSession`)
  - free-form JSON fields → `JSONValue.swift` (Codable type-erased JSON for `Record<string, unknown>` shapes)
- **SPM dependencies**: `jedisct1/swift-sodium` (libsodium for #15) and `kishikawakatsumi/KeychainAccess` (Keychain for #15/#18).
- **Tests** (`HMANBridgeClientTests`): URL construction, leading-slash validation, in-memory token round-trip, snake_case + ISO-8601 decode round-trip on `GatesResponse`.
- **CI**: new `ios-build` job on `macos-14` runs `swift build` from `apps/ios`. `xcodebuild` deferred — arrives once we have an `.xcodeproj` for device builds.
- **README** at `apps/ios/README.md`: layout, requirements, CLI build, Xcode flow, simulator + device guidance, dep list, CI notes.

## Files

```
apps/ios/
├── Package.swift
├── README.md
├── Sources/HMAN/
│   ├── HMANApp.swift
│   ├── ContentView.swift
│   ├── Bridge/HMANBridgeClient.swift
│   ├── Models/{AccessRequest,AuditEntry,Gates,JSONValue,Permission,Vault}.swift
│   └── Views/{Welcome,Onboarding,Dashboard,Gates,Memory,Audit}View.swift
└── Tests/HMANTests/HMANBridgeClientTests.swift
```

Plus `.github/workflows/ci.yml`: `+5 -0` adding the `ios-build` job.

## Test plan

- [ ] CI `ios-build` job goes green on `macos-14` (`swift build`)
- [ ] CI `swift test` (run locally — not part of CI yet)
- [ ] Open `apps/ios/Package.swift` in Xcode 15+, scheme HMAN, simulator iOS 17.5 — tab bar renders, placeholder views navigate
- [ ] `HMANBridgeClient(baseURL:).health()` against a running `packages/python-bridge` returns the parsed `BridgeHealth`
- [ ] Wave 2 sub-issues (#14-#18) can branch from this without touching the chassis

## Non-goals (intentional)

- No real features — every screen is a placeholder
- No App Store / TestFlight / signing certs (out of scope)
- No `xcodebuild` step in CI (no `.xcodeproj` yet — added in a follow-up if the team wants it)