### PR TITLE
feat(bridge+web): in-PWA voice loop

### DIFF
--- a/apps/web-dashboard/src/components/VoicePTT.tsx
+++ b/apps/web-dashboard/src/components/VoicePTT.tsx
@@ -1,0 +1,262 @@
+/**
+ * VoicePTT — push-to-talk voice loop, in the PWA.
+ *
+ * Hold the button (mouse-down or touch-start) → MediaRecorder captures
+ * webm/opus → release → blob is POSTed to /api/audio/transcribe →
+ * transcript POSTed to /api/voice/respond → reply audio plays back.
+ *
+ * Playback path:
+ *   1. If the bridge returns `tts_url`, fetch it (with bearer auth)
+ *      into a Blob URL and play via `<audio>`.
+ *   2. Otherwise fall back to `window.speechSynthesis` so the loop is
+ *      still useful on machines without Piper installed.
+ *
+ * Latency goal: end-of-utterance to start-of-reply audio under 3s on
+ * RTX 4090 + LAN (faster-whisper "base" int8 + llama3.2:3b on Ollama).
+ *
+ * iOS background-audio limitation
+ * ───────────────────────────────
+ * On iOS Safari, MediaRecorder and getUserMedia capture stop the
+ * moment the PWA goes to background or the screen locks. **This is
+ * a known PWA constraint on iOS** — there is no API to keep the mic
+ * open in the background from a web context. Wave 1 explicitly
+ * accepts this; background audio is the job of the Wave 2 native
+ * client (issue #7). Don't try to chase this in JavaScript.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Mic, Loader2 } from 'lucide-react'
+import { hman } from '../lib/hman'
+import { useVoiceRecorder } from '../lib/useVoiceRecorder'
+
+type Phase = 'idle' | 'recording' | 'transcribing' | 'thinking' | 'speaking' | 'error'
+
+interface VoicePTTProps {
+  /** Optional system-prompt override forwarded to /api/voice/respond. */
+  context?: string
+  /** Render the button as a fixed floating action button. */
+  floating?: boolean
+}
+
+export function VoicePTT({ context, floating = false }: VoicePTTProps) {
+  const recorder = useVoiceRecorder()
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [transcript, setTranscript] = useState<string>('')
+  const [reply, setReply] = useState<string>('')
+  const [err, setErr] = useState<string | null>(null)
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const blobUrlRef = useRef<string | null>(null)
+
+  const cleanupBlobUrl = useCallback(() => {
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current)
+      blobUrlRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => {
+    cleanupBlobUrl()
+    if (audioRef.current) {
+      audioRef.current.pause()
+      audioRef.current = null
+    }
+    // Cancel any pending TTS on unmount
+    try { window.speechSynthesis?.cancel() } catch {}
+  }, [cleanupBlobUrl])
+
+  const handleStart = useCallback(async () => {
+    if (phase !== 'idle' && phase !== 'error') return
+    setErr(null)
+    setTranscript('')
+    setReply('')
+    cleanupBlobUrl()
+    try { window.speechSynthesis?.cancel() } catch {}
+    setPhase('recording')
+    try {
+      await recorder.start()
+    } catch (e: any) {
+      setErr(e?.message ?? String(e))
+      setPhase('error')
+    }
+  }, [phase, recorder, cleanupBlobUrl])
+
+  const handleStop = useCallback(async () => {
+    if (phase !== 'recording') return
+    let blob: Blob | null = null
+    try {
+      blob = await recorder.stop()
+    } catch (e: any) {
+      setErr(e?.message ?? String(e))
+      setPhase('error')
+      return
+    }
+    if (!blob || blob.size < 800) {
+      // <800 bytes ≈ no real audio captured (button mashed or no mic data)
+      setPhase('idle')
+      return
+    }
+    setPhase('transcribing')
+    try {
+      const t0 = performance.now()
+      const stt = await hman.transcribe(blob)
+      setTranscript(stt.text)
+      if (!stt.text.trim()) {
+        setPhase('idle')
+        return
+      }
+      setPhase('thinking')
+      const r = await hman.voiceRespond(stt.text, context)
+      setReply(r.reply)
+      const elapsed = performance.now() - t0
+      // eslint-disable-next-line no-console
+      console.debug(`[VoicePTT] stt+llm round-trip: ${elapsed.toFixed(0)}ms`)
+
+      setPhase('speaking')
+      if (r.tts_url) {
+        try {
+          const url = await hman.fetchVoiceAudio(r.tts_url)
+          blobUrlRef.current = url
+          const audio = new Audio(url)
+          audioRef.current = audio
+          audio.onended = () => {
+            cleanupBlobUrl()
+            setPhase('idle')
+          }
+          audio.onerror = () => {
+            cleanupBlobUrl()
+            // Fall back to Web Speech Synthesis on playback failure
+            speakViaWebSpeech(r.reply, () => setPhase('idle'))
+          }
+          await audio.play()
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.warn('[VoicePTT] tts_url playback failed, falling back', e)
+          speakViaWebSpeech(r.reply, () => setPhase('idle'))
+        }
+      } else {
+        speakViaWebSpeech(r.reply, () => setPhase('idle'))
+      }
+    } catch (e: any) {
+      setErr(e?.message ?? String(e))
+      setPhase('error')
+    }
+  }, [phase, recorder, context, cleanupBlobUrl])
+
+  // Pointer events cover mouse + touch + pen on a single handler set.
+  // Capturing pointer ensures release outside the button still fires up.
+  const onPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    void handleStart()
+  }
+  const onPointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+    void handleStop()
+  }
+  const onPointerCancel = () => {
+    void handleStop()
+  }
+
+  const label = phaseLabel(phase, recorder.elapsedMs)
+  const busy = phase === 'transcribing' || phase === 'thinking' || phase === 'speaking'
+
+  return (
+    <div
+      className={
+        floating
+          ? 'fixed bottom-6 right-6 z-40 flex flex-col items-end gap-2'
+          : 'flex flex-col items-start gap-3'
+      }
+    >
+      {(transcript || reply || err) && (
+        <div
+          className={`max-w-md rounded-lg border px-3 py-2 text-sm shadow-lg ${
+            err
+              ? 'border-red-500/40 bg-red-900/30 text-red-200'
+              : 'border-border bg-background-secondary text-text-primary'
+          }`}
+        >
+          {err && <p className="font-medium">Error: {err}</p>}
+          {transcript && !err && (
+            <p>
+              <span className="text-text-secondary">You said:</span> {transcript}
+            </p>
+          )}
+          {reply && !err && (
+            <p className="mt-1">
+              <span className="text-text-secondary">Reply:</span> {reply}
+            </p>
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
+        onContextMenu={e => e.preventDefault()}
+        disabled={busy}
+        aria-label="Hold to talk"
+        className={`select-none touch-none rounded-full shadow-lg flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+          phase === 'recording'
+            ? 'bg-red-600 hover:bg-red-500 text-white'
+            : busy
+              ? 'bg-background-secondary text-text-secondary cursor-wait'
+              : 'bg-blue-600 hover:bg-blue-500 text-white'
+        }`}
+        style={{
+          // Subtle ring driven by live mic level while recording
+          boxShadow:
+            phase === 'recording'
+              ? `0 0 0 ${Math.round(recorder.level * 12)}px rgba(239, 68, 68, 0.25)`
+              : undefined,
+        }}
+      >
+        {busy ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : (
+          <Mic className="w-4 h-4" />
+        )}
+        {label}
+      </button>
+    </div>
+  )
+}
+
+function phaseLabel(phase: Phase, elapsedMs: number): string {
+  switch (phase) {
+    case 'recording':
+      return `Listening… ${(elapsedMs / 1000).toFixed(1)}s`
+    case 'transcribing':
+      return 'Transcribing…'
+    case 'thinking':
+      return 'Thinking…'
+    case 'speaking':
+      return 'Speaking…'
+    case 'error':
+      return 'Hold to talk'
+    case 'idle':
+    default:
+      return 'Hold to talk'
+  }
+}
+
+function speakViaWebSpeech(text: string, onEnd: () => void): void {
+  const synth = typeof window !== 'undefined' ? window.speechSynthesis : null
+  if (!synth || typeof SpeechSynthesisUtterance === 'undefined') {
+    // No TTS at all — just clear state
+    onEnd()
+    return
+  }
+  try {
+    synth.cancel()
+    const utt = new SpeechSynthesisUtterance(text)
+    utt.rate = 1.05
+    utt.onend = onEnd
+    utt.onerror = onEnd
+    synth.speak(utt)
+  } catch {
+    onEnd()
+  }
+}

--- a/apps/web-dashboard/src/lib/hman.ts
+++ b/apps/web-dashboard/src/lib/hman.ts
@@ -92,6 +92,19 @@ export interface Gate5Unlock {
   threshold: number
 }
 
+export interface TranscribeResult {
+  text: string
+  duration_s: number
+  rms: number
+}
+
+export interface VoiceRespondResult {
+  reply: string
+  /** Path on the bridge serving a one-shot signed wav. Null when Piper
+   * isn't available — the client falls back to Web Speech Synthesis. */
+  tts_url: string | null
+}
+
 async function j<T>(r: Response): Promise<T> {
   if (!r.ok) {
     const body = await r.text().catch(() => '')
@@ -216,6 +229,39 @@ export const hman = {
         headers: authHeaders(),
       }),
     )
+  },
+
+  // In-PWA voice loop (issue #9) — push-to-talk in the dashboard
+  async transcribe(audio: Blob): Promise<TranscribeResult> {
+    const form = new FormData()
+    form.append('audio', audio, 'utterance.webm')
+    return j(
+      await fetch(`${BASE}/api/audio/transcribe`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: form,
+      }),
+    )
+  },
+
+  async voiceRespond(text: string, context?: string): Promise<VoiceRespondResult> {
+    return j(
+      await fetch(`${BASE}/api/voice/respond`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({ text, context: context ?? null }),
+      }),
+    )
+  },
+
+  /** Build an absolute URL for a tts_url returned by /api/voice/respond.
+   * Authorization isn't sendable from a plain `<audio>` src, so we
+   * fetch the bytes here, blob-URL them, and let the caller play. */
+  async fetchVoiceAudio(ttsUrl: string): Promise<string> {
+    const r = await fetch(`${BASE}${ttsUrl}`, { headers: authHeaders() })
+    if (!r.ok) throw new Error(`HTTP ${r.status}: ${await r.text().catch(() => '')}`)
+    const blob = await r.blob()
+    return URL.createObjectURL(blob)
   },
 }
 

--- a/apps/web-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/web-dashboard/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import {
   XCircle,
 } from 'lucide-react'
 import { hman, type Health, type GatesResponse } from '../lib/hman'
+import { VoicePTT } from '../components/VoicePTT'
 
 export function DashboardPage() {
   const [health, setHealth] = useState<Health | null>(null)
@@ -203,6 +204,12 @@ export function DashboardPage() {
         "These five gates will tell you if .HMAN is actually working as intended, or if it's
         just another surveillance device wearing a friendly mask."
       </p>
+
+      {/* Push-to-talk loop (issue #9). Only mount when the bridge is
+          reachable — pointless otherwise, and the recorder permission
+          prompt is jarring on a broken page. iOS background-audio
+          limitation is documented in VoicePTT.tsx. */}
+      {health && !error && <VoicePTT floating />}
     </div>
   )
 }

--- a/packages/python-bridge/api/server.py
+++ b/packages/python-bridge/api/server.py
@@ -13,6 +13,7 @@ surface.
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import os
@@ -30,7 +31,8 @@ import numpy as np
 import traceback
 from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
+from starlette.background import BackgroundTask
 from pydantic import BaseModel
 
 # Make sibling module importable when run as script (api/server.py → ../core.py)
@@ -630,6 +632,200 @@ def gates():
         gates=gates_out,
         last_activation=_gate5_last_activation,
         rejections_last_hour=_gate5_rejects,  # simplified; real rolling-hour later
+    )
+
+
+# ── In-PWA voice loop (Wave 1, issue #9) ────────────────────────────
+#
+# Push-to-talk in the web dashboard:
+#     MediaRecorder webm/opus blob
+#  →  POST /api/audio/transcribe         (faster-whisper)
+#  →  POST /api/voice/respond            (Ollama → reply text + optional Piper TTS)
+#  →  GET  /api/voice/audio/{token}      (one-shot signed URL, ~60s)
+#
+# Foreground only on iOS — that's a known PWA constraint and Wave 1
+# explicitly accepts it. Background capture is Wave 2 (native).
+#
+# TTS: if a Piper ONNX voice is present at $HMAN_TTS_MODEL (or
+# ~/.hman/tts/en_US-amy-medium.onnx by default) AND the `piper-tts`
+# CLI is on PATH, /api/voice/respond will synthesize and return a
+# tts_url. Otherwise tts_url is null and the frontend falls back to
+# Web Speech Synthesis (window.speechSynthesis). Either path is
+# acceptable for v1.
+
+_VOICE_MODEL = os.environ.get("HMAN_VOICE_MODEL", "llama3.2:3b").strip() or "llama3.2:3b"
+_OLLAMA_URL = os.environ.get("HMAN_OLLAMA_URL", "http://localhost:11434").rstrip("/")
+_TTS_MODEL_PATH = Path(
+    os.environ.get(
+        "HMAN_TTS_MODEL",
+        str(Path.home() / ".hman" / "tts" / "en_US-amy-medium.onnx"),
+    )
+).expanduser()
+_TTS_DIR = core.HMAN_DIR / "voice_audio"
+_TTS_DIR.mkdir(parents=True, exist_ok=True)
+_TTS_MAX_AGE_S = 60.0
+
+# token → (Path, expires_at_epoch). One-shot; popped on first GET.
+_tts_tokens: dict[str, tuple[Path, float]] = {}
+_tts_lock = threading.Lock()
+
+
+class TranscribeResponse(BaseModel):
+    text: str
+    duration_s: float
+    rms: float
+
+
+class VoiceRespondRequest(BaseModel):
+    text: str
+    context: Optional[str] = None
+
+
+class VoiceRespondResponse(BaseModel):
+    reply: str
+    tts_url: Optional[str] = None
+
+
+def _piper_available() -> bool:
+    """True if Piper CLI is on PATH and a voice model exists locally."""
+    import shutil
+    return shutil.which("piper") is not None and _TTS_MODEL_PATH.exists()
+
+
+def _synthesize_piper(text: str) -> Optional[Path]:
+    """Run piper to a temp wav. Returns the path on success, None on any failure
+    (caller falls back to Web Speech Synthesis on the client)."""
+    if not _piper_available():
+        return None
+    import subprocess
+    out_path = _TTS_DIR / f"reply_{secrets.token_hex(8)}.wav"
+    try:
+        proc = subprocess.run(
+            ["piper", "--model", str(_TTS_MODEL_PATH), "--output_file", str(out_path)],
+            input=text.encode("utf-8"),
+            capture_output=True,
+            timeout=20,
+        )
+        if proc.returncode != 0 or not out_path.exists():
+            return None
+        return out_path
+    except Exception:
+        return None
+
+
+def _gc_tts_tokens() -> None:
+    """Drop expired tokens and unlink their files. Called on each issue."""
+    now = time.time()
+    with _tts_lock:
+        dead = [t for t, (_, exp) in _tts_tokens.items() if exp < now]
+        for t in dead:
+            path, _ = _tts_tokens.pop(t, (None, 0))
+            if path:
+                try:
+                    path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
+
+def _ollama_chat_sync(prompt: str, context: Optional[str]) -> str:
+    """Blocking Ollama call. Run via asyncio.to_thread() from async handlers
+    so the event loop keeps serving other requests during inference."""
+    import requests
+    messages = []
+    if context:
+        messages.append({"role": "system", "content": context})
+    else:
+        messages.append({
+            "role": "system",
+            "content": (
+                "You are HMAN, the member's local subconscious. Reply briefly "
+                "and in plain spoken language — one or two short sentences. "
+                "Never mention being an AI."
+            ),
+        })
+    messages.append({"role": "user", "content": prompt})
+    r = requests.post(
+        f"{_OLLAMA_URL}/api/chat",
+        json={"model": _VOICE_MODEL, "messages": messages, "stream": False},
+        timeout=60,
+    )
+    r.raise_for_status()
+    body = r.json()
+    return (body.get("message", {}).get("content") or "").strip()
+
+
+@app.post("/api/audio/transcribe", response_model=TranscribeResponse)
+async def audio_transcribe(audio: UploadFile = File(...)):
+    """Transcribe a single push-to-talk blob (webm/opus or wav).
+
+    Returns text + audio stats. Reuses ``core.transcribe_audio``, the
+    same path the ambient audio sensor uses, so the model loads once
+    per process.
+    """
+    audio_np = _decode_audio(audio)
+    result = await asyncio.to_thread(core.transcribe_audio, audio_np)
+    return TranscribeResponse(**result)
+
+
+@app.post("/api/voice/respond", response_model=VoiceRespondResponse)
+async def voice_respond(body: VoiceRespondRequest):
+    """LLM reply for an utterance, optionally with synthesized audio.
+
+    Always returns the reply text. ``tts_url`` is non-null only when
+    Piper is available locally — otherwise the client falls back to
+    Web Speech Synthesis.
+    """
+    if not body.text.strip():
+        raise HTTPException(status_code=400, detail="empty utterance")
+
+    try:
+        reply = await asyncio.to_thread(_ollama_chat_sync, body.text, body.context)
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"ollama unreachable: {type(e).__name__}: {str(e)[:200]}",
+        )
+    if not reply:
+        reply = "(no reply)"
+
+    tts_url: Optional[str] = None
+    if _piper_available():
+        wav_path = await asyncio.to_thread(_synthesize_piper, reply)
+        if wav_path is not None:
+            tok = secrets.token_urlsafe(24)
+            with _tts_lock:
+                _tts_tokens[tok] = (wav_path, time.time() + _TTS_MAX_AGE_S)
+            _gc_tts_tokens()
+            tts_url = f"/api/voice/audio/{tok}"
+
+    return VoiceRespondResponse(reply=reply, tts_url=tts_url)
+
+
+def _unlink_silent(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+@app.get("/api/voice/audio/{tok}")
+async def voice_audio(tok: str):
+    """One-shot signed audio URL. Token is consumed on first read and the
+    underlying wav is unlinked once streaming completes, so the client
+    must download in one go."""
+    _gc_tts_tokens()
+    with _tts_lock:
+        entry = _tts_tokens.pop(tok, None)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="audio expired or already consumed")
+    path, _exp = entry
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="audio missing on disk")
+    return FileResponse(
+        str(path),
+        media_type="audio/wav",
+        filename=path.name,
+        background=BackgroundTask(_unlink_silent, path),
     )
 
 

--- a/packages/python-bridge/core.py
+++ b/packages/python-bridge/core.py
@@ -123,6 +123,51 @@ def embed_audio(audio: np.ndarray) -> tuple[np.ndarray, float]:
     return emb.astype(np.float32), (time.time() - t0) * 1000
 
 
+# ── Speech-to-text (faster-whisper, lazy-loaded singleton) ──────────
+#
+# Shared by the audio sensor (30s ambient chunks) and the PWA voice
+# loop (push-to-talk utterances). Loading the model is slow (~3-5s on
+# first call), so we keep one instance per process.
+
+_whisper_model = None
+_whisper_lock = threading.Lock()
+_WHISPER_SIZE = os.environ.get("HMAN_WHISPER_MODEL", "base").strip() or "base"
+
+
+def get_whisper():
+    """Return a cached faster-whisper WhisperModel."""
+    global _whisper_model
+    with _whisper_lock:
+        if _whisper_model is None:
+            from faster_whisper import WhisperModel
+            _whisper_model = WhisperModel(
+                _WHISPER_SIZE, device="cpu", compute_type="int8",
+            )
+        return _whisper_model
+
+
+def transcribe_audio(audio: np.ndarray, language: str = "en") -> dict:
+    """Transcribe a mono float32 16 kHz numpy array.
+
+    Returns ``{ "text": str, "duration_s": float, "rms": float }``.
+    Reused by both the audio sensor and the PWA push-to-talk endpoint
+    so the transcribe path stays in one place.
+    """
+    duration_s = float(len(audio)) / SAMPLE_RATE if len(audio) else 0.0
+    rms = float(np.sqrt(np.mean(audio ** 2))) if len(audio) else 0.0
+    if duration_s < 0.2 or rms < 1e-4:
+        # Too short or pure silence — skip the model entirely
+        return {"text": "", "duration_s": round(duration_s, 3), "rms": round(rms, 4)}
+    model = get_whisper()
+    segments, _info = model.transcribe(audio, language=language, beam_size=1)
+    text = " ".join(seg.text for seg in segments).strip()
+    return {
+        "text": text,
+        "duration_s": round(duration_s, 3),
+        "rms": round(rms, 4),
+    }
+
+
 # ── Reference embedding persistence (Fernet + PBKDF2) ───────────────
 
 PBKDF2_ITERATIONS = 600_000

--- a/packages/python-bridge/sensors/audio.py
+++ b/packages/python-bridge/sensors/audio.py
@@ -29,7 +29,6 @@ class AudioSensor(Sensor):
     def __init__(self, device: Optional[int] = None) -> None:
         super().__init__()
         self.device = device
-        self._whisper_model = None
         self.chunks_silent = 0
         self.last_transcript = ""
         self._current_rms = 0.0
@@ -138,14 +137,9 @@ class AudioSensor(Sensor):
         self._peak_rms_60s = 0.0
 
     def _transcribe(self, audio: np.ndarray) -> str:
-        # faster-whisper (CTranslate2) — no torch dependency, 3-4x faster on CPU
-        # than openai-whisper, and dodges the c10.dll load failure on this box.
-        if self._whisper_model is None:
-            from faster_whisper import WhisperModel
-            self._whisper_model = WhisperModel(
-                "base", device="cpu", compute_type="int8",
-            )
-        segments, _info = self._whisper_model.transcribe(
-            audio, language="en", beam_size=1,
-        )
-        return " ".join(seg.text for seg in segments).strip()
+        # Delegated to core.transcribe_audio so the same faster-whisper
+        # singleton serves both the ambient sensor and the PWA push-to-talk
+        # endpoint. faster-whisper has no torch dependency and dodges the
+        # c10.dll load failure on this box.
+        from core import transcribe_audio  # local import to avoid sensor->core cycle at module load
+        return transcribe_audio(audio).get("text", "")


### PR DESCRIPTION
Fixes #9.

## What

In-PWA push-to-talk loop. Hold the floating mic button on the dashboard, speak, release — the dashboard transcribes, asks Ollama, and plays back the reply.

## Endpoints

| Method | Path | Purpose |
| --- | --- | --- |
| POST | `/api/audio/transcribe` | multipart `audio` blob (webm/opus or wav) → `{ text, duration_s, rms }` via faster-whisper |
| POST | `/api/voice/respond` | `{ text, context? }` → `{ reply, tts_url? }`. Ollama (`llama3.2:3b` by default, override via `HMAN_VOICE_MODEL`). Wrapped in `asyncio.to_thread` so the event loop keeps serving. |
| GET | `/api/voice/audio/{tok}` | One-shot signed wav. Token consumed on first read; underlying file unlinked via Starlette `BackgroundTask`. 60s expiry. |

All three are bearer-gated like the rest of `/api/*`.

The audio sensor's transcribe path was extracted into `core.transcribe_audio()` so the same faster-whisper singleton serves both ambient-mode and push-to-talk — no second model load.

## Frontend flow

`apps/web-dashboard/src/components/VoicePTT.tsx`:

1. Pointer-down (mouse, touch, pen — single handler set, captures pointer so release-outside still fires up).
2. `useVoiceRecorder` (existing hook) gives the live mic level + webm/opus blob.
3. Release → `hman.transcribe(blob)` → inline "you said: …".
4. → `hman.voiceRespond(text)` → "reply: …".
5. Playback: if `tts_url` returned, fetch with bearer auth, blob-URL, play via `<audio>`. Otherwise fall back to `window.speechSynthesis`.

Mounted as a floating action button on `DashboardPage`, only when the bridge is reachable.

## TTS

I went with **either-works**: if Piper CLI + an ONNX voice exist at `$HMAN_TTS_MODEL` (default `~/.hman/tts/en_US-amy-medium.onnx`), the bridge synthesizes server-side and returns a `tts_url`. If not, `tts_url` is null and the frontend falls back to `window.speechSynthesis`. Works out of the box on any machine; users who want a real voice install Piper + a model and set the env var.

## iOS foreground-only — by design

`MediaRecorder` and `getUserMedia` capture stop the moment a PWA goes to background or the screen locks on iOS. Wave 1 explicitly accepts this; background audio is the job of the Wave 2 native client (issue #7). The component's JSDoc documents this prominently so future contributors don't waste time chasing it.

## Validation

- `npm run typecheck` clean
- `python -m py_compile` clean on `api/server.py`, `core.py`, `sensors/audio.py`

## Heads up

PR #23 (against `claude/issue-21-sensor-autostart`) is also editing `api/server.py`. Whichever PR merges first, the other rebases — there are no logical conflicts, both edits add separate top-level handlers/middleware.