### PR TITLE
feat(web-dashboard): mobile-responsive audit across all member pages

### DIFF
--- a/apps/web-dashboard/src/components/Layout.tsx
+++ b/apps/web-dashboard/src/components/Layout.tsx
@@ -3,12 +3,9 @@ import {
   Power,
   Folder,
   Settings,
-  Menu,
-  X,
   Mic,
   Shield,
 } from 'lucide-react'
-import { useState } from 'react'
 
 const navItems = [
   { path: '/app', label: 'Subconscious', icon: Power, end: true },
@@ -18,42 +15,22 @@ const navItems = [
 ]
 
 export function Layout() {
-  const [sidebarOpen, setSidebarOpen] = useState(false)
-
   return (
-    <div className="flex h-screen bg-background">
-      {/* Mobile sidebar overlay */}
-      {sidebarOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
-
-      {/* Sidebar */}
-      <aside
-        className={`fixed inset-y-0 left-0 z-50 w-64 transform bg-background-secondary border-r border-border transition-transform lg:translate-x-0 lg:static ${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        }`}
-        style={{
-          paddingLeft: 'var(--safe-left)',
-          paddingBottom: 'var(--safe-bottom)',
-        }}
-      >
-        <div
-          className="flex min-h-16 items-center gap-3 border-b border-border px-6"
-          style={{ paddingTop: 'var(--safe-top)' }}
-        >
+    <div
+      className="flex min-h-screen bg-background"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingLeft: 'env(safe-area-inset-left)',
+        paddingRight: 'env(safe-area-inset-right)',
+      }}
+    >
+      {/* Desktop sidebar — hidden on mobile, visible from md up */}
+      <aside className="hidden md:flex md:flex-col md:w-64 md:shrink-0 md:border-r md:border-border md:bg-background-secondary">
+        <div className="flex h-16 items-center gap-3 border-b border-border px-6">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary">
             <Shield className="h-5 w-5 text-white" />
           </div>
           <span className="text-xl font-bold">HMAN</span>
-          <button
-            className="ml-auto lg:hidden"
-            onClick={() => setSidebarOpen(false)}
-          >
-            <X className="h-5 w-5" />
-          </button>
         </div>
 
         <nav className="flex flex-col gap-1 p-4">
@@ -63,13 +40,12 @@ export function Layout() {
               to={item.path}
               end={item.end ?? false}
               className={({ isActive }) =>
-                `flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
+                `flex min-h-11 items-center gap-3 rounded-lg px-4 py-3 text-base font-medium transition-colors ${
                   isActive
                     ? 'bg-primary text-white'
                     : 'text-gray-400 hover:bg-surface hover:text-white'
                 }`
               }
-              onClick={() => setSidebarOpen(false)}
             >
               <item.icon className="h-5 w-5" />
               {item.label}
@@ -77,7 +53,7 @@ export function Layout() {
           ))}
         </nav>
 
-        <div className="absolute bottom-0 left-0 right-0 border-t border-border p-4">
+        <div className="mt-auto border-t border-border p-4">
           <div className="flex items-center gap-3">
             <div className="h-10 w-10 rounded-full bg-primary/20 flex items-center justify-center">
               <span className="text-sm font-medium text-primary">M1</span>
@@ -91,31 +67,45 @@ export function Layout() {
       </aside>
 
       {/* Main content */}
-      <main
-        className="flex-1 overflow-auto"
-        style={{
-          paddingRight: 'var(--safe-right)',
-          paddingBottom: 'var(--safe-bottom)',
-        }}
-      >
-        {/* Mobile header — extra top padding so it clears the iOS notch */}
-        <header
-          className="sticky top-0 z-30 flex min-h-16 items-center gap-4 border-b border-border bg-background px-4 lg:hidden"
-          style={{ paddingTop: 'var(--safe-top)' }}
-        >
-          <button onClick={() => setSidebarOpen(true)}>
-            <Menu className="h-6 w-6" />
-          </button>
+      <main className="flex-1 min-w-0 flex flex-col">
+        {/* Mobile header — hidden on desktop */}
+        <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-background px-4 md:hidden">
           <div className="flex items-center gap-2">
             <Shield className="h-6 w-6 text-primary" />
             <span className="text-lg font-bold">HMAN</span>
           </div>
         </header>
 
-        <div className="p-6">
+        <div className="flex-1 p-4 md:p-6 pb-24 md:pb-6">
           <Outlet />
         </div>
       </main>
+
+      {/* Mobile bottom tab bar — hidden on desktop. Respects home-indicator safe area. */}
+      <nav
+        className="md:hidden fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background-secondary"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        <div className="flex items-stretch justify-around">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              end={item.end ?? false}
+              className={({ isActive }) =>
+                `flex flex-1 min-h-14 min-w-11 flex-col items-center justify-center gap-1 px-2 py-2 text-xs font-medium transition-colors ${
+                  isActive
+                    ? 'text-primary'
+                    : 'text-gray-400 hover:text-white'
+                }`
+              }
+            >
+              <item.icon className="h-5 w-5" />
+              <span className="leading-none">{item.label}</span>
+            </NavLink>
+          ))}
+        </div>
+      </nav>
     </div>
   )
 }

--- a/apps/web-dashboard/src/pages/AuditPage.tsx
+++ b/apps/web-dashboard/src/pages/AuditPage.tsx
@@ -231,18 +231,18 @@ export function AuditPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold">Audit Log</h1>
-          <p className="text-gray-400">Complete history of all vault activity</p>
+          <p className="text-gray-400 text-base">Complete history of all vault activity</p>
         </div>
-        <button className="flex items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 font-medium hover:bg-background-tertiary">
+        <button className="min-h-11 flex items-center justify-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 font-medium hover:bg-background-tertiary text-base">
           <Download className="h-5 w-5" />
           Export
         </button>
       </div>
 
       {/* Stats */}
-      <div className="flex gap-6">
+      <div className="flex flex-wrap gap-4 sm:gap-6">
         <div className="flex items-center gap-2">
           <CheckCircle className="h-5 w-5 text-level-open" />
           <span className="text-sm">
@@ -268,16 +268,16 @@ export function AuditPage() {
             placeholder="Search audit log..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-lg border border-border bg-surface py-3 pl-10 pr-4 text-white placeholder-gray-400 focus:border-primary focus:outline-none"
+            className="w-full min-h-11 rounded-lg border border-border bg-surface py-3 pl-10 pr-4 text-base text-white placeholder-gray-400 focus:border-primary focus:outline-none"
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <Filter className="h-5 w-5 text-gray-400 flex-shrink-0" />
           {(['all', 'access', 'changes', 'security'] as FilterType[]).map((f) => (
             <button
               key={f}
               onClick={() => setFilter(f)}
-              className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+              className={`min-h-11 rounded-full px-4 py-2 text-sm font-medium transition-colors ${
                 filter === f
                   ? 'bg-primary text-white'
                   : 'bg-surface text-gray-400 hover:text-white'
@@ -289,8 +289,8 @@ export function AuditPage() {
         </div>
       </div>
 
-      {/* Audit Log Table */}
-      <div className="rounded-xl border border-border bg-surface overflow-hidden">
+      {/* Audit Log — desktop table (md+) */}
+      <div className="hidden md:block rounded-xl border border-border bg-surface overflow-hidden">
         <table className="w-full">
           <thead className="border-b border-border bg-background-secondary">
             <tr>
@@ -340,7 +340,7 @@ export function AuditPage() {
                     </div>
                   </td>
                   <td className="px-6 py-4">
-                    <span className="text-primary">
+                    <span className="text-primary break-all">
                       {entry.resourceUri.replace('hman://', '')}
                     </span>
                   </td>
@@ -355,6 +355,58 @@ export function AuditPage() {
 
         {filteredEntries.length === 0 && (
           <div className="p-12 text-center">
+            <Shield className="mx-auto h-12 w-12 text-gray-400" />
+            <h3 className="mt-4 font-semibold">No entries found</h3>
+            <p className="mt-2 text-sm text-gray-400">
+              Try adjusting your search or filter criteria
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Audit Log — mobile cards (below md) */}
+      <div className="md:hidden space-y-3">
+        {filteredEntries.map((entry) => {
+          const ActionIcon = getActionIcon(entry.action)
+          const ActorIcon = getActorIcon(entry.actorType)
+          const colorClass = getActionColor(entry.action, entry.success)
+
+          return (
+            <div
+              key={entry.id}
+              className="rounded-xl border border-border bg-surface p-4"
+            >
+              <div className="flex items-start gap-3">
+                <div
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${colorClass}`}
+                >
+                  <ActionIcon className="h-5 w-5" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium break-words">
+                    {formatActionLabel(entry.action)}
+                  </div>
+                  {entry.details && (
+                    <div className="text-sm text-gray-400 break-words">{entry.details}</div>
+                  )}
+                  <div className="mt-2 flex items-center gap-2 text-sm">
+                    <ActorIcon className="h-4 w-4 text-gray-400 shrink-0" />
+                    <span className="truncate">{entry.actorName}</span>
+                  </div>
+                  <div className="mt-1 text-sm text-primary break-all">
+                    {entry.resourceUri.replace('hman://', '')}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-400">
+                    {formatTimestamp(entry.timestamp)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+
+        {filteredEntries.length === 0 && (
+          <div className="rounded-xl border border-border bg-surface p-12 text-center">
             <Shield className="mx-auto h-12 w-12 text-gray-400" />
             <h3 className="mt-4 font-semibold">No entries found</h3>
             <p className="mt-2 text-sm text-gray-400">

--- a/apps/web-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/web-dashboard/src/pages/DashboardPage.tsx
@@ -47,16 +47,16 @@ export function DashboardPage() {
 
   return (
     <div className="max-w-5xl">
-      <div className="flex items-start justify-between mb-8">
-        <div>
-          <h1 className="text-3xl font-semibold text-text-primary">.HMAN</h1>
-          <p className="text-text-secondary mt-1">
+      <div className="flex items-start justify-between gap-3 mb-6 sm:mb-8">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary">.HMAN</h1>
+          <p className="text-text-secondary mt-1 text-base">
             Your local subconscious. Encrypted, yours.
           </p>
         </div>
         <button
           onClick={refresh}
-          className="p-2 rounded-lg hover:bg-background-secondary text-text-secondary"
+          className="shrink-0 min-h-11 min-w-11 p-2 rounded-lg hover:bg-background-secondary text-text-secondary inline-flex items-center justify-center"
           title="Refresh"
         >
           <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
@@ -78,21 +78,21 @@ export function DashboardPage() {
 
       {health && gates && (
         <div
-          className={`rounded-lg border p-5 mb-6 ${
+          className={`rounded-lg border p-4 sm:p-5 mb-6 ${
             allPass
               ? 'border-green-500/40 bg-green-900/10'
               : 'border-amber-500/40 bg-amber-900/10'
           }`}
         >
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-3 sm:gap-4 flex-wrap">
             {allPass ? (
               <ShieldCheck className="w-10 h-10 text-green-400 shrink-0" />
             ) : (
               <ShieldAlert className="w-10 h-10 text-amber-400 shrink-0" />
             )}
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <p className="text-lg font-medium text-text-primary">
+              <div className="flex items-center gap-2 mb-1 flex-wrap">
+                <p className="text-base sm:text-lg font-medium text-text-primary">
                   {passing}/{total} gates armed
                 </p>
                 {allPass && (
@@ -109,7 +109,7 @@ export function DashboardPage() {
             </div>
             <Link
               to="/app/gates"
-              className="shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-background-secondary border border-border hover:bg-background text-text-primary text-sm"
+              className="shrink-0 min-h-11 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-background-secondary border border-border hover:bg-background text-text-primary text-base"
             >
               View gates <ArrowRight className="w-4 h-4" />
             </Link>
@@ -163,17 +163,17 @@ export function DashboardPage() {
             {gates.gates.map(g => (
               <div
                 key={g.name}
-                className="flex items-center gap-3 py-2 border-b border-border last:border-b-0"
+                className="flex items-start gap-3 py-2 border-b border-border last:border-b-0 flex-wrap sm:flex-nowrap"
               >
                 {g.passing ? (
-                  <CheckCircle2 className="w-4 h-4 text-green-400 shrink-0" />
+                  <CheckCircle2 className="w-4 h-4 text-green-400 shrink-0 mt-0.5" />
                 ) : (
-                  <XCircle className="w-4 h-4 text-amber-400 shrink-0" />
+                  <XCircle className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
                 )}
-                <span className="font-medium text-text-primary flex-1 min-w-0 truncate">
+                <span className="font-medium text-text-primary flex-1 min-w-0 break-words">
                   {g.name}
                 </span>
-                <span className="text-xs text-text-secondary truncate max-w-[55%]">
+                <span className="text-xs text-text-secondary w-full sm:w-auto sm:max-w-[55%] sm:truncate pl-7 sm:pl-0">
                   {g.detail}
                 </span>
               </div>
@@ -183,9 +183,9 @@ export function DashboardPage() {
       )}
 
       {health && !health.enrolled && (
-        <div className="rounded-lg border border-blue-500/40 bg-blue-900/10 p-5 flex items-center gap-4">
+        <div className="rounded-lg border border-blue-500/40 bg-blue-900/10 p-4 sm:p-5 flex items-center gap-4 flex-wrap">
           <Mic className="w-6 h-6 text-blue-400 shrink-0" />
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <p className="font-medium text-text-primary">Start onboarding</p>
             <p className="text-sm text-text-secondary">
               Bind your voice. Ten prompts, two minutes. Closes Gate 5.
@@ -193,7 +193,7 @@ export function DashboardPage() {
           </div>
           <Link
             to="/app/onboarding"
-            className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium"
+            className="min-h-11 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-base font-medium inline-flex items-center"
           >
             Begin
           </Link>

--- a/apps/web-dashboard/src/pages/DelegationsPage.tsx
+++ b/apps/web-dashboard/src/pages/DelegationsPage.tsx
@@ -101,15 +101,15 @@ export function DelegationsPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold">Delegations</h1>
-          <p className="text-gray-400">
+          <p className="text-gray-400 text-base">
             Manage trusted contacts who can access your vaults
           </p>
         </div>
         <button
           onClick={() => setShowInviteModal(true)}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium hover:bg-primary-dark"
+          className="min-h-11 flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium hover:bg-primary-dark text-base"
         >
           <Plus className="h-5 w-5" />
           Invite Delegate
@@ -166,28 +166,31 @@ export function DelegationsPage() {
           </div>
           <div className="divide-y divide-border">
             {pendingDelegations.map((delegation) => (
-              <div key={delegation.id} className="flex items-center justify-between p-4">
-                <div className="flex items-center gap-4">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-level-gated/20">
+              <div key={delegation.id} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4">
+                <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-level-gated/20">
                     <span className="text-sm font-medium text-level-gated">
                       {delegation.name.charAt(0)}
                     </span>
                   </div>
-                  <div>
-                    <div className="font-medium">{delegation.name}</div>
-                    <div className="text-sm text-gray-400">{delegation.email}</div>
+                  <div className="min-w-0">
+                    <div className="font-medium truncate">{delegation.name}</div>
+                    <div className="text-sm text-gray-400 truncate">{delegation.email}</div>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <button className="flex items-center gap-1 rounded-lg border border-border bg-background-tertiary px-3 py-1.5 text-sm hover:bg-surface">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button className="min-h-11 flex items-center gap-1 rounded-lg border border-border bg-background-tertiary px-3 py-1.5 text-sm hover:bg-surface">
                     <Copy className="h-4 w-4" />
                     Copy Link
                   </button>
-                  <button className="flex items-center gap-1 rounded-lg border border-border bg-background-tertiary px-3 py-1.5 text-sm hover:bg-surface">
+                  <button className="min-h-11 flex items-center gap-1 rounded-lg border border-border bg-background-tertiary px-3 py-1.5 text-sm hover:bg-surface">
                     <Mail className="h-4 w-4" />
                     Resend
                   </button>
-                  <button className="rounded-lg border border-level-locked/50 p-1.5 text-level-locked hover:bg-level-locked/20">
+                  <button
+                    aria-label="Revoke invite"
+                    className="min-h-11 min-w-11 inline-flex items-center justify-center rounded-lg border border-level-locked/50 p-1.5 text-level-locked hover:bg-level-locked/20"
+                  >
                     <Trash2 className="h-4 w-4" />
                   </button>
                 </div>
@@ -210,17 +213,17 @@ export function DelegationsPage() {
             const StatusIcon = statusIcons[delegation.status]
 
             return (
-              <div key={delegation.id} className="p-6">
+              <div key={delegation.id} className="p-4 sm:p-6">
                 <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                  <div className="flex gap-4">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20">
+                  <div className="flex gap-3 sm:gap-4 min-w-0">
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary/20">
                       <span className="text-lg font-medium text-primary">
                         {delegation.name.charAt(0)}
                       </span>
                     </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-semibold">{delegation.name}</h3>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="font-semibold break-words">{delegation.name}</h3>
                         <span
                           className={`rounded-full px-2 py-0.5 text-xs font-medium ${
                             roleColors[delegation.role]
@@ -229,7 +232,7 @@ export function DelegationsPage() {
                           {roleLabels[delegation.role]}
                         </span>
                       </div>
-                      <div className="text-sm text-gray-400">{delegation.email}</div>
+                      <div className="text-sm text-gray-400 truncate">{delegation.email}</div>
 
                       {/* Permissions */}
                       <div className="mt-3">
@@ -247,21 +250,21 @@ export function DelegationsPage() {
                       </div>
 
                       {/* Meta */}
-                      <div className="mt-3 flex items-center gap-4 text-xs text-gray-400">
+                      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-gray-400">
                         <div className="flex items-center gap-1">
-                          <Calendar className="h-3 w-3" />
+                          <Calendar className="h-3 w-3 shrink-0" />
                           Added {delegation.createdAt.toLocaleDateString()}
                         </div>
                         {delegation.expiresAt && (
                           <div className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
+                            <Clock className="h-3 w-3 shrink-0" />
                             Expires {delegation.expiresAt.toLocaleDateString()}
                           </div>
                         )}
                         {delegation.lastActive && (
                           <div className="flex items-center gap-1">
                             <StatusIcon
-                              className={`h-3 w-3 ${statusColors[delegation.status]}`}
+                              className={`h-3 w-3 shrink-0 ${statusColors[delegation.status]}`}
                             />
                             Last active{' '}
                             {Math.floor(
@@ -274,11 +277,11 @@ export function DelegationsPage() {
                     </div>
                   </div>
 
-                  <div className="flex gap-2 lg:flex-shrink-0">
-                    <button className="rounded-lg border border-border bg-background-tertiary px-4 py-2 text-sm font-medium hover:bg-surface">
+                  <div className="flex gap-2 flex-wrap lg:flex-shrink-0">
+                    <button className="min-h-11 rounded-lg border border-border bg-background-tertiary px-4 py-2 text-base font-medium hover:bg-surface">
                       Edit Permissions
                     </button>
-                    <button className="rounded-lg border border-level-locked/50 px-4 py-2 text-sm font-medium text-level-locked hover:bg-level-locked/20">
+                    <button className="min-h-11 rounded-lg border border-level-locked/50 px-4 py-2 text-base font-medium text-level-locked hover:bg-level-locked/20">
                       Revoke
                     </button>
                   </div>
@@ -291,7 +294,7 @@ export function DelegationsPage() {
 
       {/* Invite Modal */}
       {showInviteModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
           <div className="w-full max-w-md rounded-xl border border-border bg-background-secondary p-6">
             <h2 className="text-xl font-bold mb-4">Invite Delegate</h2>
             <div className="space-y-4">
@@ -302,14 +305,14 @@ export function DelegationsPage() {
                 <input
                   type="email"
                   placeholder="delegate@example.com"
-                  className="w-full rounded-lg border border-border bg-surface py-2 px-3 text-white placeholder-gray-400 focus:border-primary focus:outline-none"
+                  className="w-full min-h-11 rounded-lg border border-border bg-surface py-2 px-3 text-base text-white placeholder-gray-400 focus:border-primary focus:outline-none"
                 />
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-400 mb-1">
                   Access Level
                 </label>
-                <select className="w-full rounded-lg border border-border bg-surface py-2 px-3 text-white focus:border-primary focus:outline-none">
+                <select className="w-full min-h-11 rounded-lg border border-border bg-surface py-2 px-3 text-base text-white focus:border-primary focus:outline-none">
                   <option value="limited">Limited Access</option>
                   <option value="emergency">Emergency Only</option>
                   <option value="full">Full Access</option>
@@ -318,11 +321,11 @@ export function DelegationsPage() {
               <div className="flex gap-2 pt-4">
                 <button
                   onClick={() => setShowInviteModal(false)}
-                  className="flex-1 rounded-lg border border-border bg-surface py-2 font-medium hover:bg-background-tertiary"
+                  className="flex-1 min-h-11 rounded-lg border border-border bg-surface py-2 font-medium hover:bg-background-tertiary text-base"
                 >
                   Cancel
                 </button>
-                <button className="flex-1 rounded-lg bg-primary py-2 font-medium hover:bg-primary-dark">
+                <button className="flex-1 min-h-11 rounded-lg bg-primary py-2 font-medium hover:bg-primary-dark text-base">
                   Send Invite
                 </button>
               </div>

--- a/apps/web-dashboard/src/pages/GatesPage.tsx
+++ b/apps/web-dashboard/src/pages/GatesPage.tsx
@@ -81,16 +81,16 @@ export function GatesPage() {
 
   return (
     <div className="max-w-3xl">
-      <div className="flex items-start justify-between mb-8">
-        <div>
-          <h1 className="text-3xl font-semibold text-text-primary">The Five Gates</h1>
-          <p className="text-text-secondary mt-1">
+      <div className="flex items-start justify-between gap-3 mb-6 sm:mb-8">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary">The Five Gates</h1>
+          <p className="text-text-secondary mt-1 text-base">
             Every feature must pass all five. If any gate leaks, the member is the product.
           </p>
         </div>
         <button
           onClick={refresh}
-          className="p-2 rounded-lg hover:bg-background-secondary text-text-secondary"
+          className="shrink-0 min-h-11 min-w-11 p-2 rounded-lg hover:bg-background-secondary text-text-secondary inline-flex items-center justify-center"
           title="Refresh"
         >
           <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
@@ -203,14 +203,14 @@ export function GatesPage() {
                               {gate5.armed ? (
                                 <button
                                   onClick={disarm}
-                                  className="px-3 py-1.5 rounded-md text-xs border border-border hover:bg-background-secondary inline-flex items-center gap-1.5 text-text-secondary hover:text-text-primary"
+                                  className="min-h-11 px-3 py-1.5 rounded-md text-sm border border-border hover:bg-background-secondary inline-flex items-center gap-1.5 text-text-secondary hover:text-text-primary"
                                 >
                                   <ShieldOff className="w-3.5 h-3.5" /> Disarm
                                 </button>
                               ) : (
                                 <button
                                   onClick={() => setShowArmModal(true)}
-                                  className="px-3 py-1.5 rounded-md text-xs bg-blue-600 hover:bg-blue-500 text-white inline-flex items-center gap-1.5"
+                                  className="min-h-11 px-3 py-1.5 rounded-md text-sm bg-blue-600 hover:bg-blue-500 text-white inline-flex items-center gap-1.5"
                                 >
                                   <Unlock className="w-3.5 h-3.5" /> Arm (unlock with passphrase)
                                 </button>
@@ -219,7 +219,7 @@ export function GatesPage() {
                           ) : (
                             <a
                               href="/app/onboarding"
-                              className="text-xs inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                              className="min-h-11 text-sm inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
                             >
                               <Mic className="w-3.5 h-3.5" /> Enroll your voice
                             </a>
@@ -323,23 +323,23 @@ function ArmModal({
           onChange={e => setPassphrase(e.target.value)}
           onKeyDown={e => e.key === 'Enter' && submit()}
           placeholder="Passphrase"
-          className="w-full px-4 py-2.5 rounded-lg bg-background border border-border focus:border-blue-500 focus:outline-none text-text-primary mb-2"
+          className="w-full min-h-11 px-4 py-2.5 rounded-lg bg-background border border-border focus:border-blue-500 focus:outline-none text-text-primary text-base mb-2"
         />
-        {err && <p className="text-xs text-red-400 mb-2">{err}</p>}
+        {err && <p className="text-xs text-red-400 mb-2 break-words">{err}</p>}
         <p className="text-xs text-text-secondary mb-4">
           Held in memory only. Clears on bridge restart — you'll re-arm each session.
         </p>
         <div className="flex gap-2">
           <button
             onClick={onCancel}
-            className="flex-1 px-4 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:bg-background text-sm"
+            className="flex-1 min-h-11 px-4 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:bg-background text-base"
           >
             Cancel
           </button>
           <button
             onClick={submit}
             disabled={busy}
-            className="flex-1 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-sm inline-flex items-center justify-center gap-2"
+            className="flex-1 min-h-11 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-base inline-flex items-center justify-center gap-2"
           >
             {busy ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Unlock className="w-4 h-4" />}
             Arm

--- a/apps/web-dashboard/src/pages/MemoryPage.tsx
+++ b/apps/web-dashboard/src/pages/MemoryPage.tsx
@@ -143,18 +143,18 @@ export function MemoryPage() {
 
   return (
     <div className="max-w-3xl space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-semibold text-text-primary flex items-center gap-3">
-            <Folder className="w-7 h-7 text-blue-400" /> Memory
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary flex items-center gap-3">
+            <Folder className="w-7 h-7 text-blue-400 shrink-0" /> Memory
           </h1>
-          <p className="text-text-secondary mt-1">
+          <p className="text-text-secondary mt-1 text-base">
             Everything the subconscious has captured. Last 6 hours across all sensors.
           </p>
         </div>
         <button
           onClick={refresh}
-          className="p-2 rounded-lg border border-border hover:bg-background-secondary text-text-secondary"
+          className="shrink-0 min-h-11 min-w-11 p-2 rounded-lg border border-border hover:bg-background-secondary text-text-secondary inline-flex items-center justify-center"
           title="Refresh"
         >
           <RefreshCw className="w-4 h-4" />
@@ -173,7 +173,7 @@ export function MemoryPage() {
           <button
             key={f}
             onClick={() => setFilter(f)}
-            className={`px-3 py-1.5 rounded-full text-sm transition-colors ${
+            className={`min-h-11 px-3 py-1.5 rounded-full text-sm transition-colors ${
               filter === f
                 ? 'bg-blue-600 text-white'
                 : 'bg-background-secondary border border-border text-text-secondary hover:text-text-primary'
@@ -201,10 +201,10 @@ export function MemoryPage() {
             {filtered.map((row, i) => {
               const Icon = SENSOR_ICONS[row._sensor] ?? Ear
               return (
-                <li key={i} className="px-5 py-3 flex gap-3">
+                <li key={i} className="px-4 sm:px-5 py-3 flex gap-3">
                   <Icon className="w-4 h-4 text-text-secondary shrink-0 mt-0.5" />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 text-xs text-text-secondary mb-1">
+                  <div className="flex-1 min-w-0 break-words">
+                    <div className="flex items-center gap-2 text-xs text-text-secondary mb-1 flex-wrap">
                       <span className="uppercase tracking-wider">{row._sensor}</span>
                       <span>·</span>
                       <span>{formatRelative(String(row.ts))}</span>
@@ -218,7 +218,7 @@ export function MemoryPage() {
         )}
       </div>
 
-      <p className="text-xs text-text-secondary font-mono">{memoryDir}</p>
+      <p className="text-xs text-text-secondary font-mono break-all">{memoryDir}</p>
     </div>
   )
 }

--- a/apps/web-dashboard/src/pages/OnboardingPage.tsx
+++ b/apps/web-dashboard/src/pages/OnboardingPage.tsx
@@ -152,8 +152,8 @@ export function OnboardingPage() {
   if (step === 'intro') {
     return (
       <div className="max-w-2xl">
-        <h1 className="text-3xl font-semibold text-text-primary mb-2">Welcome to .HMAN</h1>
-        <p className="text-text-secondary mb-8">
+        <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary mb-2">Welcome to .HMAN</h1>
+        <p className="text-text-secondary mb-8 text-base">
           Your personal subconscious. Local, encrypted, yours.
         </p>
 
@@ -189,7 +189,7 @@ export function OnboardingPage() {
 
         <button
           onClick={() => setStep('passphrase')}
-          className="px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium inline-flex items-center gap-2"
+          className="min-h-11 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium inline-flex items-center gap-2 text-base"
         >
           Begin enrollment <ArrowRight className="w-4 h-4" />
         </button>
@@ -200,8 +200,8 @@ export function OnboardingPage() {
   if (step === 'passphrase') {
     return (
       <div className="max-w-md">
-        <h1 className="text-3xl font-semibold text-text-primary mb-2">Choose a passphrase</h1>
-        <p className="text-text-secondary mb-6">
+        <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary mb-2">Choose a passphrase</h1>
+        <p className="text-text-secondary mb-6 text-base">
           Encrypts your voice identity at rest. Eight characters minimum. No recovery — lose this
           and you re-enroll.
         </p>
@@ -213,20 +213,20 @@ export function OnboardingPage() {
             value={passphrase}
             onChange={e => setPassphrase(e.target.value)}
             placeholder="Passphrase"
-            className="w-full px-4 py-3 rounded-lg bg-background-secondary border border-border focus:border-blue-500 focus:outline-none text-text-primary"
+            className="w-full min-h-11 px-4 py-3 rounded-lg bg-background-secondary border border-border focus:border-blue-500 focus:outline-none text-text-primary text-base"
           />
           <input
             type="password"
             value={confirm}
             onChange={e => setConfirm(e.target.value)}
             placeholder="Confirm"
-            className="w-full px-4 py-3 rounded-lg bg-background-secondary border border-border focus:border-blue-500 focus:outline-none text-text-primary"
+            className="w-full min-h-11 px-4 py-3 rounded-lg bg-background-secondary border border-border focus:border-blue-500 focus:outline-none text-text-primary text-base"
             onKeyDown={e => e.key === 'Enter' && startSession()}
           />
           {passphraseError && <p className="text-sm text-red-400">{passphraseError}</p>}
           <button
             onClick={startSession}
-            className="w-full px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium"
+            className="w-full min-h-11 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium text-base"
           >
             Continue
           </button>
@@ -238,37 +238,39 @@ export function OnboardingPage() {
   if (step === 'recording' && session) {
     return (
       <div className="max-w-2xl">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h1 className="text-3xl font-semibold text-text-primary">
+        <div className="flex items-center justify-between gap-3 mb-6">
+          <div className="min-w-0">
+            <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary">
               {done ? 'Review' : `Prompt ${completed + 1} of ${session.total}`}
             </h1>
-            <p className="text-text-secondary">
+            <p className="text-text-secondary text-base">
               {done
                 ? 'All prompts captured. Review consistency then finalize.'
                 : 'Read the line out loud. It advances when you pause.'}
             </p>
           </div>
-          <ProgressRing value={completed / session.total} />
+          <div className="shrink-0">
+            <ProgressRing value={completed / session.total} />
+          </div>
         </div>
 
         {!done && currentPrompt && (
           <>
-            <div className="rounded-lg border border-border bg-background-secondary p-8 mb-6">
-              <p className="text-xl text-text-primary leading-relaxed font-serif">
+            <div className="rounded-lg border border-border bg-background-secondary p-6 sm:p-8 mb-6">
+              <p className="text-lg sm:text-xl text-text-primary leading-relaxed font-serif break-words">
                 "{currentPrompt}"
               </p>
             </div>
 
-            <div className="rounded-lg border border-border bg-background-secondary p-6 mb-6">
+            <div className="rounded-lg border border-border bg-background-secondary p-4 sm:p-6 mb-6">
               <LevelMeter level={rec.level} state={rec.state} />
-              <div className="flex items-center justify-between mt-4">
+              <div className="flex items-center justify-between flex-wrap gap-3 mt-4">
                 <StatusBadge state={rec.state} uploading={uploading} />
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   {rec.state === 'idle' && (
                     <button
                       onClick={() => rec.start()}
-                      className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium inline-flex items-center gap-2"
+                      className="min-h-11 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-base font-medium inline-flex items-center gap-2"
                     >
                       <Play className="w-4 h-4" /> Start listening
                     </button>
@@ -276,7 +278,7 @@ export function OnboardingPage() {
                   {(rec.state === 'listening' || rec.state === 'recording') && (
                     <button
                       onClick={() => rec.pause()}
-                      className="px-3 py-2 rounded-lg bg-background border border-border text-text-secondary hover:text-text-primary text-sm inline-flex items-center gap-2"
+                      className="min-h-11 px-3 py-2 rounded-lg bg-background border border-border text-text-secondary hover:text-text-primary text-base inline-flex items-center gap-2"
                     >
                       <Pause className="w-4 h-4" /> Pause
                     </button>
@@ -284,7 +286,7 @@ export function OnboardingPage() {
                   {rec.state === 'paused' && (
                     <button
                       onClick={() => rec.resume()}
-                      className="px-3 py-2 rounded-lg bg-background border border-border text-text-secondary hover:text-text-primary text-sm inline-flex items-center gap-2"
+                      className="min-h-11 px-3 py-2 rounded-lg bg-background border border-border text-text-secondary hover:text-text-primary text-base inline-flex items-center gap-2"
                     >
                       <Play className="w-4 h-4" /> Resume
                     </button>
@@ -370,7 +372,7 @@ export function OnboardingPage() {
         {done && (
           <button
             onClick={finalize}
-            className="w-full px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium"
+            className="w-full min-h-11 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium text-base"
           >
             Finalize enrollment
           </button>
@@ -394,8 +396,8 @@ export function OnboardingPage() {
     return (
       <div className="max-w-2xl">
         <div className="flex items-center gap-3 mb-6">
-          <CheckCircle2 className="w-8 h-8 text-green-400" />
-          <h1 className="text-3xl font-semibold text-text-primary">Enrolled</h1>
+          <CheckCircle2 className="w-8 h-8 text-green-400 shrink-0" />
+          <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary">Enrolled</h1>
         </div>
         <p className="text-text-secondary mb-8">
           Your voice identity is saved locally, encrypted at rest. Gate 5 runtime verification lands
@@ -421,14 +423,14 @@ export function OnboardingPage() {
   if (step === 'error') {
     return (
       <div className="max-w-md">
-        <h1 className="text-3xl font-semibold text-red-400 mb-2">Something broke</h1>
-        <p className="text-text-secondary mb-6">{error}</p>
+        <h1 className="text-2xl sm:text-3xl font-semibold text-red-400 mb-2">Something broke</h1>
+        <p className="text-text-secondary mb-6 break-words">{error}</p>
         <button
           onClick={() => {
             setError(null)
             setStep('intro')
           }}
-          className="px-6 py-3 rounded-lg bg-background-secondary border border-border hover:bg-background text-text-primary"
+          className="min-h-11 px-6 py-3 rounded-lg bg-background-secondary border border-border hover:bg-background text-text-primary text-base"
         >
           Back to start
         </button>

--- a/apps/web-dashboard/src/pages/RequestsPage.tsx
+++ b/apps/web-dashboard/src/pages/RequestsPage.tsx
@@ -228,16 +228,16 @@ export function RequestsPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold">Access Requests</h1>
-          <p className="text-gray-400">
+          <p className="text-gray-400 text-base">
             {pendingCount} pending request{pendingCount !== 1 && 's'} awaiting your approval
           </p>
         </div>
         <button
           onClick={() => loadData(true)}
           disabled={isRefreshing}
-          className="flex items-center gap-2 rounded-lg bg-surface border border-border px-4 py-2 text-sm font-medium hover:bg-background-tertiary disabled:opacity-50 transition-colors"
+          className="min-h-11 flex items-center justify-center gap-2 rounded-lg bg-surface border border-border px-4 py-2 text-base font-medium hover:bg-background-tertiary disabled:opacity-50 transition-colors"
         >
           <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
           {isRefreshing ? 'Refreshing...' : 'Refresh'}
@@ -258,14 +258,14 @@ export function RequestsPage() {
       )}
 
       {/* Filters */}
-      <div className="flex items-center gap-2 overflow-x-auto pb-2">
+      <div className="flex items-center gap-2 overflow-x-auto pb-2 -mx-4 px-4 sm:mx-0 sm:px-0">
         <Filter className="h-5 w-5 text-gray-400 flex-shrink-0" />
         {(['all', 'pending', 'approved', 'denied', 'expired'] as FilterStatus[]).map(
           (status) => (
             <button
               key={status}
               onClick={() => setFilter(status)}
-              className={`flex-shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+              className={`flex-shrink-0 min-h-11 rounded-full px-4 py-2 text-sm font-medium transition-colors ${
                 filter === status
                   ? 'bg-primary text-white'
                   : 'bg-surface text-gray-400 hover:text-white'
@@ -292,12 +292,12 @@ export function RequestsPage() {
           return (
             <div
               key={request.id}
-              className={`rounded-xl border bg-surface p-6 ${
+              className={`rounded-xl border bg-surface p-4 sm:p-6 ${
                 request.status === 'pending' ? 'border-level-gated' : 'border-border'
               }`}
             >
               <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                <div className="flex gap-4">
+                <div className="flex gap-3 sm:gap-4 min-w-0">
                   {/* Requester Icon */}
                   <div
                     className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg ${
@@ -320,22 +320,22 @@ export function RequestsPage() {
                   </div>
 
                   {/* Request Info */}
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
-                      <h3 className="font-semibold">{request.requesterName}</h3>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h3 className="font-semibold break-words">{request.requesterName}</h3>
                       <span className="text-sm text-gray-400">
                         ({request.requesterType.replace('_', ' ')})
                       </span>
                     </div>
-                    <div className="mt-1 text-sm text-primary">
+                    <div className="mt-1 text-sm text-primary break-words">
                       {request.resourceName}
                     </div>
-                    <p className="mt-2 text-sm text-gray-400">{request.purpose}</p>
+                    <p className="mt-2 text-sm text-gray-400 break-words">{request.purpose}</p>
 
                     {/* Status */}
-                    <div className="mt-3 flex items-center gap-4">
+                    <div className="mt-3 flex items-center gap-4 flex-wrap">
                       <div className={`flex items-center gap-1.5 ${statusColor}`}>
-                        <StatusIcon className="h-4 w-4" />
+                        <StatusIcon className="h-4 w-4 shrink-0" />
                         <span className="text-sm font-medium capitalize">
                           {request.status}
                         </span>
@@ -351,11 +351,11 @@ export function RequestsPage() {
 
                 {/* Actions */}
                 {request.status === 'pending' && (
-                  <div className="flex gap-2 lg:flex-shrink-0">
+                  <div className="flex gap-2 flex-wrap lg:flex-shrink-0">
                     <button
                       onClick={() => handleApprove(request.id)}
                       disabled={actionInProgress === request.id}
-                      className="flex items-center gap-2 rounded-lg bg-level-open px-4 py-2 text-sm font-medium text-black hover:bg-level-open/90 disabled:opacity-50 transition-colors"
+                      className="min-h-11 flex items-center gap-2 rounded-lg bg-level-open px-4 py-2 text-base font-medium text-black hover:bg-level-open/90 disabled:opacity-50 transition-colors"
                     >
                       {actionInProgress === request.id ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -367,7 +367,7 @@ export function RequestsPage() {
                     <button
                       onClick={() => handleDeny(request.id)}
                       disabled={actionInProgress === request.id}
-                      className="flex items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 text-sm font-medium hover:bg-background-tertiary disabled:opacity-50 transition-colors"
+                      className="min-h-11 flex items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 text-base font-medium hover:bg-background-tertiary disabled:opacity-50 transition-colors"
                     >
                       {actionInProgress === request.id ? (
                         <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/web-dashboard/src/pages/SettingsPage.tsx
+++ b/apps/web-dashboard/src/pages/SettingsPage.tsx
@@ -44,23 +44,25 @@ export function SettingsPage() {
 
   return (
     <div className="flex flex-col lg:flex-row gap-6">
-      {/* Sidebar */}
-      <div className="lg:w-64 flex-shrink-0">
-        <nav className="rounded-xl border border-border bg-surface p-2">
-          {sections.map((section) => (
-            <button
-              key={section.id}
-              onClick={() => setActiveSection(section.id)}
-              className={`flex w-full items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
-                activeSection === section.id
-                  ? 'bg-primary text-white'
-                  : 'text-gray-400 hover:bg-background-tertiary hover:text-white'
-              } ${section.id === 'danger' ? 'text-level-locked' : ''}`}
-            >
-              <section.icon className="h-5 w-5" />
-              {section.title}
-            </button>
-          ))}
+      {/* Sidebar — horizontal scroll chips on mobile, vertical list on lg */}
+      <div className="lg:w-64 lg:flex-shrink-0">
+        <nav className="lg:rounded-xl lg:border lg:border-border lg:bg-surface lg:p-2 -mx-4 sm:mx-0 lg:mx-0 px-4 sm:px-0 lg:px-0 overflow-x-auto lg:overflow-visible">
+          <div className="flex gap-2 lg:flex-col lg:gap-0 min-w-max lg:min-w-0">
+            {sections.map((section) => (
+              <button
+                key={section.id}
+                onClick={() => setActiveSection(section.id)}
+                className={`min-h-11 flex shrink-0 items-center gap-3 rounded-lg px-4 py-3 text-base font-medium transition-colors lg:w-full ${
+                  activeSection === section.id
+                    ? 'bg-primary text-white'
+                    : 'text-gray-400 hover:bg-background-tertiary hover:text-white'
+                } ${section.id === 'danger' ? 'text-level-locked' : ''}`}
+              >
+                <section.icon className="h-5 w-5 shrink-0" />
+                {section.title}
+              </button>
+            ))}
+          </div>
         </nav>
       </div>
 
@@ -68,13 +70,13 @@ export function SettingsPage() {
       <div className="flex-1 space-y-6">
         {activeSection === 'profile' && (
           <>
-            <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
               <h2 className="text-lg font-semibold mb-6">Profile Information</h2>
-              <div className="flex items-start gap-6">
-                <div className="h-20 w-20 rounded-full bg-primary/20 flex items-center justify-center">
+              <div className="flex flex-col sm:flex-row items-start gap-4 sm:gap-6">
+                <div className="h-20 w-20 shrink-0 rounded-full bg-primary/20 flex items-center justify-center">
                   <span className="text-2xl font-bold text-primary">JD</span>
                 </div>
-                <div className="flex-1 space-y-4">
+                <div className="flex-1 min-w-0 w-full space-y-4">
                   <div>
                     <label className="block text-sm font-medium text-gray-400 mb-1">
                       Display Name
@@ -82,7 +84,7 @@ export function SettingsPage() {
                     <input
                       type="text"
                       defaultValue="John Doe"
-                      className="w-full max-w-md rounded-lg border border-border bg-background-tertiary py-2 px-3 text-white focus:border-primary focus:outline-none"
+                      className="w-full max-w-md min-h-11 rounded-lg border border-border bg-background-tertiary py-2 px-3 text-base text-white focus:border-primary focus:outline-none"
                     />
                   </div>
                   <div>
@@ -92,42 +94,42 @@ export function SettingsPage() {
                     <input
                       type="email"
                       defaultValue="john.doe@example.com"
-                      className="w-full max-w-md rounded-lg border border-border bg-background-tertiary py-2 px-3 text-white focus:border-primary focus:outline-none"
+                      className="w-full max-w-md min-h-11 rounded-lg border border-border bg-background-tertiary py-2 px-3 text-base text-white focus:border-primary focus:outline-none"
                     />
                   </div>
                 </div>
               </div>
-              <button className="mt-6 rounded-lg bg-primary px-4 py-2 font-medium hover:bg-primary-dark">
+              <button className="mt-6 min-h-11 rounded-lg bg-primary px-4 py-2 font-medium hover:bg-primary-dark text-base">
                 Save Changes
               </button>
             </div>
 
-            <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
               <h2 className="text-lg font-semibold mb-4">Preferences</h2>
               <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Moon className="h-5 w-5 text-gray-400" />
-                    <div>
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Moon className="h-5 w-5 text-gray-400 shrink-0" />
+                    <div className="min-w-0">
                       <div className="font-medium">Theme</div>
                       <div className="text-sm text-gray-400">Choose your preferred theme</div>
                     </div>
                   </div>
-                  <select className="rounded-lg border border-border bg-background-tertiary py-2 px-3 text-white focus:border-primary focus:outline-none">
+                  <select className="min-h-11 rounded-lg border border-border bg-background-tertiary py-2 px-3 text-base text-white focus:border-primary focus:outline-none">
                     <option value="dark">Dark</option>
                     <option value="light">Light</option>
                     <option value="system">System</option>
                   </select>
                 </div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Globe className="h-5 w-5 text-gray-400" />
-                    <div>
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Globe className="h-5 w-5 text-gray-400 shrink-0" />
+                    <div className="min-w-0">
                       <div className="font-medium">Language</div>
                       <div className="text-sm text-gray-400">Select your language</div>
                     </div>
                   </div>
-                  <select className="rounded-lg border border-border bg-background-tertiary py-2 px-3 text-white focus:border-primary focus:outline-none">
+                  <select className="min-h-11 rounded-lg border border-border bg-background-tertiary py-2 px-3 text-base text-white focus:border-primary focus:outline-none">
                     <option value="en">English</option>
                     <option value="es">Spanish</option>
                     <option value="fr">French</option>
@@ -140,15 +142,15 @@ export function SettingsPage() {
 
         {activeSection === 'security' && (
           <>
-            <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
               <h2 className="text-lg font-semibold mb-6">Authentication</h2>
               <div className="space-y-6">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-level-gated/20">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-level-gated/20">
                       <Key className="h-5 w-5 text-level-gated" />
                     </div>
-                    <div>
+                    <div className="min-w-0">
                       <div className="font-medium">Biometric Unlock</div>
                       <div className="text-sm text-gray-400">
                         Use Face ID or Touch ID to unlock
@@ -157,24 +159,29 @@ export function SettingsPage() {
                   </div>
                   <button
                     onClick={() => setBiometricEnabled(!biometricEnabled)}
-                    className={`relative h-6 w-11 rounded-full transition-colors ${
-                      biometricEnabled ? 'bg-primary' : 'bg-border'
-                    }`}
+                    aria-label={`Biometric unlock ${biometricEnabled ? 'on' : 'off'}`}
+                    className="shrink-0 min-h-11 min-w-11 inline-flex items-center justify-center"
                   >
                     <span
-                      className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
-                        biometricEnabled ? 'translate-x-5' : 'translate-x-0.5'
+                      className={`relative block h-6 w-11 rounded-full transition-colors ${
+                        biometricEnabled ? 'bg-primary' : 'bg-border'
                       }`}
-                    />
+                    >
+                      <span
+                        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                          biometricEnabled ? 'translate-x-5' : 'translate-x-0.5'
+                        }`}
+                      />
+                    </span>
                   </button>
                 </div>
 
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-level-gated/20">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-level-gated/20">
                       <Lock className="h-5 w-5 text-level-gated" />
                     </div>
-                    <div>
+                    <div className="min-w-0">
                       <div className="font-medium">Auto-Lock</div>
                       <div className="text-sm text-gray-400">
                         Lock when app is in background
@@ -183,20 +190,25 @@ export function SettingsPage() {
                   </div>
                   <button
                     onClick={() => setAutoLockEnabled(!autoLockEnabled)}
-                    className={`relative h-6 w-11 rounded-full transition-colors ${
-                      autoLockEnabled ? 'bg-primary' : 'bg-border'
-                    }`}
+                    aria-label={`Auto-lock ${autoLockEnabled ? 'on' : 'off'}`}
+                    className="shrink-0 min-h-11 min-w-11 inline-flex items-center justify-center"
                   >
                     <span
-                      className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
-                        autoLockEnabled ? 'translate-x-5' : 'translate-x-0.5'
+                      className={`relative block h-6 w-11 rounded-full transition-colors ${
+                        autoLockEnabled ? 'bg-primary' : 'bg-border'
                       }`}
-                    />
+                    >
+                      <span
+                        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                          autoLockEnabled ? 'translate-x-5' : 'translate-x-0.5'
+                        }`}
+                      />
+                    </span>
                   </button>
                 </div>
 
                 <div className="border-t border-border pt-6">
-                  <button className="flex items-center gap-2 rounded-lg border border-border bg-background-tertiary px-4 py-2 font-medium hover:bg-surface">
+                  <button className="min-h-11 flex items-center gap-2 rounded-lg border border-border bg-background-tertiary px-4 py-2 font-medium hover:bg-surface text-base">
                     <Key className="h-5 w-5" />
                     Change Passphrase
                   </button>
@@ -204,19 +216,19 @@ export function SettingsPage() {
               </div>
             </div>
 
-            <div className="rounded-xl border border-border bg-surface p-6">
+            <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
               <h2 className="text-lg font-semibold mb-4">Security Status</h2>
               <div className="space-y-4">
                 <div className="flex items-center gap-3">
-                  <CheckCircle className="h-5 w-5 text-level-open" />
+                  <CheckCircle className="h-5 w-5 text-level-open shrink-0" />
                   <span>End-to-end encryption active</span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <CheckCircle className="h-5 w-5 text-level-open" />
+                  <CheckCircle className="h-5 w-5 text-level-open shrink-0" />
                   <span>Zero-access architecture verified</span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <CheckCircle className="h-5 w-5 text-level-open" />
+                  <CheckCircle className="h-5 w-5 text-level-open shrink-0" />
                   <span>Audit log chain intact</span>
                 </div>
               </div>
@@ -225,11 +237,11 @@ export function SettingsPage() {
         )}
 
         {activeSection === 'notifications' && (
-          <div className="rounded-xl border border-border bg-surface p-6">
+          <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
             <h2 className="text-lg font-semibold mb-6">Notification Settings</h2>
             <div className="space-y-6">
-              <div className="flex items-center justify-between">
-                <div>
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
                   <div className="font-medium">Push Notifications</div>
                   <div className="text-sm text-gray-400">
                     Receive alerts for access requests
@@ -237,20 +249,25 @@ export function SettingsPage() {
                 </div>
                 <button
                   onClick={() => setNotificationsEnabled(!notificationsEnabled)}
-                  className={`relative h-6 w-11 rounded-full transition-colors ${
-                    notificationsEnabled ? 'bg-primary' : 'bg-border'
-                  }`}
+                  aria-label={`Push notifications ${notificationsEnabled ? 'on' : 'off'}`}
+                  className="shrink-0 min-h-11 min-w-11 inline-flex items-center justify-center"
                 >
                   <span
-                    className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
-                      notificationsEnabled ? 'translate-x-5' : 'translate-x-0.5'
+                    className={`relative block h-6 w-11 rounded-full transition-colors ${
+                      notificationsEnabled ? 'bg-primary' : 'bg-border'
                     }`}
-                  />
+                  >
+                    <span
+                      className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        notificationsEnabled ? 'translate-x-5' : 'translate-x-0.5'
+                      }`}
+                    />
+                  </span>
                 </button>
               </div>
 
-              <div className="flex items-center justify-between">
-                <div>
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
                   <div className="font-medium">Email Digest</div>
                   <div className="text-sm text-gray-400">
                     Weekly summary of vault activity
@@ -258,15 +275,20 @@ export function SettingsPage() {
                 </div>
                 <button
                   onClick={() => setEmailDigest(!emailDigest)}
-                  className={`relative h-6 w-11 rounded-full transition-colors ${
-                    emailDigest ? 'bg-primary' : 'bg-border'
-                  }`}
+                  aria-label={`Email digest ${emailDigest ? 'on' : 'off'}`}
+                  className="shrink-0 min-h-11 min-w-11 inline-flex items-center justify-center"
                 >
                   <span
-                    className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
-                      emailDigest ? 'translate-x-5' : 'translate-x-0.5'
+                    className={`relative block h-6 w-11 rounded-full transition-colors ${
+                      emailDigest ? 'bg-primary' : 'bg-border'
                     }`}
-                  />
+                  >
+                    <span
+                      className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        emailDigest ? 'translate-x-5' : 'translate-x-0.5'
+                      }`}
+                    />
+                  </span>
                 </button>
               </div>
             </div>
@@ -274,18 +296,18 @@ export function SettingsPage() {
         )}
 
         {activeSection === 'devices' && (
-          <div className="rounded-xl border border-border bg-surface p-6">
+          <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
             <h2 className="text-lg font-semibold mb-6">Connected Devices</h2>
             <div className="space-y-4">
               {connectedDevices.map((device, i) => (
                 <div
                   key={i}
-                  className="flex items-center justify-between rounded-lg border border-border p-4"
+                  className="flex items-center justify-between gap-3 rounded-lg border border-border p-4 flex-wrap"
                 >
-                  <div className="flex items-center gap-4">
-                    <Smartphone className="h-6 w-6 text-primary" />
-                    <div>
-                      <div className="font-medium flex items-center gap-2">
+                  <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+                    <Smartphone className="h-6 w-6 text-primary shrink-0" />
+                    <div className="min-w-0">
+                      <div className="font-medium flex items-center gap-2 flex-wrap">
                         {device.name}
                         {device.current && (
                           <span className="rounded bg-level-open/20 px-2 py-0.5 text-xs text-level-open">
@@ -299,7 +321,7 @@ export function SettingsPage() {
                     </div>
                   </div>
                   {!device.current && (
-                    <button className="text-sm text-level-locked hover:underline">
+                    <button className="min-h-11 px-2 text-base text-level-locked hover:underline">
                       Remove
                     </button>
                   )}
@@ -310,15 +332,15 @@ export function SettingsPage() {
         )}
 
         {activeSection === 'backup' && (
-          <div className="rounded-xl border border-border bg-surface p-6">
+          <div className="rounded-xl border border-border bg-surface p-4 sm:p-6">
             <h2 className="text-lg font-semibold mb-6">Backup & Sync</h2>
             <div className="space-y-6">
-              <div className="flex items-center gap-4">
-                <button className="flex items-center gap-2 rounded-lg border border-border bg-background-tertiary px-4 py-3 font-medium hover:bg-surface">
+              <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:gap-4">
+                <button className="min-h-11 flex items-center justify-center gap-2 rounded-lg border border-border bg-background-tertiary px-4 py-3 font-medium hover:bg-surface text-base">
                   <Download className="h-5 w-5" />
                   Export Encrypted Backup
                 </button>
-                <button className="flex items-center gap-2 rounded-lg border border-border bg-background-tertiary px-4 py-3 font-medium hover:bg-surface">
+                <button className="min-h-11 flex items-center justify-center gap-2 rounded-lg border border-border bg-background-tertiary px-4 py-3 font-medium hover:bg-surface text-base">
                   <Upload className="h-5 w-5" />
                   Import Backup
                 </button>
@@ -332,17 +354,17 @@ export function SettingsPage() {
         )}
 
         {activeSection === 'danger' && (
-          <div className="rounded-xl border border-level-locked bg-surface p-6">
+          <div className="rounded-xl border border-level-locked bg-surface p-4 sm:p-6">
             <h2 className="text-lg font-semibold text-level-locked mb-4">Danger Zone</h2>
-            <p className="text-gray-400 mb-6">
+            <p className="text-gray-400 mb-6 text-base">
               These actions are irreversible. Please proceed with caution.
             </p>
             <div className="space-y-4">
-              <button className="flex items-center gap-2 rounded-lg border border-level-locked/50 px-4 py-2 text-level-locked hover:bg-level-locked/20">
+              <button className="min-h-11 flex items-center gap-2 rounded-lg border border-level-locked/50 px-4 py-2 text-level-locked hover:bg-level-locked/20 text-base">
                 <Trash2 className="h-5 w-5" />
                 Delete All Vault Data
               </button>
-              <button className="flex items-center gap-2 rounded-lg border border-level-locked/50 px-4 py-2 text-level-locked hover:bg-level-locked/20">
+              <button className="min-h-11 flex items-center gap-2 rounded-lg border border-level-locked/50 px-4 py-2 text-level-locked hover:bg-level-locked/20 text-base">
                 <Trash2 className="h-5 w-5" />
                 Delete Account
               </button>

--- a/apps/web-dashboard/src/pages/SubconsciousPage.tsx
+++ b/apps/web-dashboard/src/pages/SubconsciousPage.tsx
@@ -101,7 +101,7 @@ function LiveChips({ sensor }: { sensor: SensorStatus }) {
       chips.push(<Chip key="chunks">{(s.chunks_captured as number) ?? 0} chunks</Chip>)
       if (s.last_transcript) {
         chips.push(
-          <span key="last" className="text-xs text-text-secondary italic truncate max-w-md">
+          <span key="last" className="text-xs text-text-secondary italic truncate max-w-full sm:max-w-md w-full sm:w-auto">
             "{String(s.last_transcript).slice(0, 90)}"
           </span>,
         )
@@ -269,24 +269,24 @@ export function SubconsciousPage() {
 
   return (
     <div className="max-w-4xl space-y-6">
-      <div className="rounded-xl border border-border bg-background-secondary p-6">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-3xl font-semibold text-text-primary flex items-center gap-3">
-              <Power className={`w-8 h-8 ${anyRunning ? 'text-green-400' : 'text-gray-500'}`} />
+      <div className="rounded-xl border border-border bg-background-secondary p-4 sm:p-6">
+        <div className="flex flex-col sm:flex-row items-start sm:justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-2xl sm:text-3xl font-semibold text-text-primary flex items-center gap-3">
+              <Power className={`w-7 h-7 sm:w-8 sm:h-8 shrink-0 ${anyRunning ? 'text-green-400' : 'text-gray-500'}`} />
               Subconscious
             </h1>
-            <p className="text-text-secondary mt-2 max-w-xl">
+            <p className="text-text-secondary mt-2 max-w-xl text-base">
               Reactive, not invasive. Listens continuously, writes to a local memory store, never interrupts.
             </p>
             <p className="mt-3 text-sm text-text-secondary">
               {runningCount} of {availableCount} available sensors active
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 w-full sm:w-auto">
             <button
               onClick={poll}
-              className="p-2 rounded-lg border border-border hover:bg-background text-text-secondary"
+              className="shrink-0 min-h-11 min-w-11 p-2 rounded-lg border border-border hover:bg-background text-text-secondary inline-flex items-center justify-center"
               title="Refresh"
             >
               <RefreshCw className="w-4 h-4" />
@@ -294,7 +294,7 @@ export function SubconsciousPage() {
             <button
               onClick={toggleAll}
               disabled={busy === '_all'}
-              className={`inline-flex items-center gap-2 px-5 py-3 rounded-lg font-medium transition-colors disabled:opacity-50 ${
+              className={`flex-1 sm:flex-none min-h-11 inline-flex items-center justify-center gap-2 px-5 py-3 rounded-lg font-medium text-base transition-colors disabled:opacity-50 ${
                 anyRunning
                   ? 'bg-background border border-border text-text-primary hover:bg-background-secondary'
                   : 'bg-blue-600 hover:bg-blue-500 text-white'
@@ -338,8 +338,8 @@ export function SubconsciousPage() {
                 s.running ? 'border-green-500/40' : 'border-border'
               } ${!s.available ? 'opacity-60' : ''}`}
             >
-              <div className="p-5 flex items-start justify-between gap-4">
-                <div className="flex items-start gap-4 flex-1 min-w-0">
+              <div className="p-4 sm:p-5 flex items-start justify-between gap-3 sm:gap-4 flex-wrap">
+                <div className="flex items-start gap-3 sm:gap-4 flex-1 min-w-0">
                   <div
                     className={`h-10 w-10 shrink-0 rounded-lg flex items-center justify-center`}
                     style={{
@@ -366,7 +366,7 @@ export function SubconsciousPage() {
                 <button
                   onClick={() => toggleSensor(s.name, s.running)}
                   disabled={disabled}
-                  className={`shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-40 ${
+                  className={`shrink-0 min-h-11 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-base font-medium transition-colors disabled:opacity-40 ${
                     s.running
                       ? 'bg-background border border-border text-text-primary hover:bg-background-secondary'
                       : 'bg-blue-600 hover:bg-blue-500 text-white'
@@ -384,8 +384,8 @@ export function SubconsciousPage() {
               </div>
 
               {/* Live trace */}
-              <div className="px-5 pb-3">
-                <div className="rounded-md bg-background/50 p-3">
+              <div className="px-4 sm:px-5 pb-3">
+                <div className="rounded-md bg-background/50 p-3 overflow-hidden">
                   {s.name === 'screen' ? (
                     <ActivityTimeline
                       segments={appSegments}
@@ -405,10 +405,10 @@ export function SubconsciousPage() {
               </div>
 
               {/* Live chips */}
-              <div className="px-5 pb-5">
+              <div className="px-4 sm:px-5 pb-4 sm:pb-5">
                 <LiveChips sensor={s} />
                 {s.last_error && (
-                  <p className="mt-2 text-xs text-amber-400 font-mono">{s.last_error}</p>
+                  <p className="mt-2 text-xs text-amber-400 font-mono break-all">{s.last_error}</p>
                 )}
               </div>
             </div>

--- a/apps/web-dashboard/src/pages/VaultsPage.tsx
+++ b/apps/web-dashboard/src/pages/VaultsPage.tsx
@@ -116,11 +116,11 @@ export function VaultsPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold">Vaults</h1>
-          <p className="text-gray-400">Manage your encrypted data vaults</p>
+          <p className="text-gray-400 text-base">Manage your encrypted data vaults</p>
         </div>
-        <button className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium hover:bg-primary-dark">
+        <button className="min-h-11 flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium hover:bg-primary-dark text-base">
           <Plus className="h-5 w-5" />
           New Vault
         </button>
@@ -134,7 +134,7 @@ export function VaultsPage() {
           placeholder="Search vaults..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full rounded-lg border border-border bg-surface py-3 pl-10 pr-4 text-white placeholder-gray-400 focus:border-primary focus:outline-none"
+          className="w-full min-h-11 rounded-lg border border-border bg-surface py-3 pl-10 pr-4 text-base text-white placeholder-gray-400 focus:border-primary focus:outline-none"
         />
       </div>
 
@@ -161,7 +161,7 @@ export function VaultsPage() {
                   <span className="text-xs">Locked</span>
                 </div>
               )}
-              <button className="opacity-0 group-hover:opacity-100 transition-opacity">
+              <button className="min-h-11 min-w-11 inline-flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 md:transition-opacity">
                 <MoreVertical className="h-5 w-5 text-gray-400 hover:text-white" />
               </button>
             </div>

--- a/apps/web-dashboard/src/pages/WelcomePage.tsx
+++ b/apps/web-dashboard/src/pages/WelcomePage.tsx
@@ -47,37 +47,46 @@ export function WelcomePage() {
   const bridgeOnline = health !== null
 
   return (
-    <div className="min-h-screen bg-background text-text-primary">
+    <div
+      className="min-h-screen bg-background text-text-primary"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingLeft: 'env(safe-area-inset-left)',
+        paddingRight: 'env(safe-area-inset-right)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
       {/* Top bar */}
-      <header className="max-w-6xl mx-auto px-6 py-6 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <ShieldCheck className="w-6 h-6 text-blue-400" />
+      <header className="max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-6 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <ShieldCheck className="w-6 h-6 text-blue-400 shrink-0" />
           <span className="text-lg font-semibold">.HMAN</span>
-          <span className="text-xs text-text-secondary ml-2">v0.1 · prototype</span>
+          <span className="hidden sm:inline text-xs text-text-secondary ml-2">v0.1 · prototype</span>
         </div>
-        <nav className="flex items-center gap-4 text-sm text-text-secondary">
+        <nav className="flex items-center gap-2 sm:gap-4 text-sm text-text-secondary">
           <a
             href="https://github.com/Tailor-AUS/Human-Managed-Access-Network"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1 hover:text-text-primary"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center gap-1 px-2 hover:text-text-primary"
           >
-            <Github className="w-4 h-4" /> Source
+            <Github className="w-4 h-4" />
+            <span className="hidden sm:inline">Source</span>
           </a>
-          <Link to="/app" className="hover:text-text-primary">
+          <Link to="/app" className="inline-flex min-h-11 items-center px-2 hover:text-text-primary">
             Member app
           </Link>
         </nav>
       </header>
 
       {/* Hero */}
-      <section className="max-w-5xl mx-auto px-6 pt-10 pb-16 text-center">
-        <h1 className="text-5xl md:text-6xl font-semibold tracking-tight mb-6 leading-tight">
+      <section className="max-w-5xl mx-auto px-4 sm:px-6 pt-6 sm:pt-10 pb-12 sm:pb-16 text-center">
+        <h1 className="text-3xl sm:text-5xl md:text-6xl font-semibold tracking-tight mb-6 leading-tight">
           Your personal subconscious.
           <br />
           <span className="text-text-secondary">Local. Encrypted. Yours.</span>
         </h1>
-        <p className="text-xl text-text-secondary max-w-2xl mx-auto mb-10">
+        <p className="text-base sm:text-xl text-text-secondary max-w-2xl mx-auto mb-8 sm:mb-10">
           .HMAN runs on your device. Not someone else&rsquo;s cloud. It listens to the signals
           only you have access to — voice, keystrokes, screen, brain — and nothing leaves without
           your explicit authorisation.
@@ -90,7 +99,7 @@ export function WelcomePage() {
           {enrolled && bridgeOnline ? (
             <Link
               to="/app"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium text-lg"
+              className="inline-flex min-h-11 items-center gap-2 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium text-base sm:text-lg"
             >
               You&rsquo;re in — continue to your .HMAN
               <ArrowRight className="w-5 h-5" />
@@ -98,14 +107,14 @@ export function WelcomePage() {
           ) : bridgeOnline ? (
             <a
               href="#install"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium text-lg"
+              className="inline-flex min-h-11 items-center gap-2 px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-medium text-base sm:text-lg"
             >
               Install to start
               <ArrowRight className="w-5 h-5" />
             </a>
           ) : (
-            <div className="inline-flex items-center gap-2 px-5 py-3 rounded-lg border border-amber-500/40 bg-amber-900/10 text-amber-300 text-sm">
-              <AlertCircle className="w-4 h-4" />
+            <div className="inline-flex items-center gap-2 px-5 py-3 rounded-lg border border-amber-500/40 bg-amber-900/10 text-amber-300 text-base">
+              <AlertCircle className="w-4 h-4 shrink-0" />
               Your local .HMAN bridge isn&rsquo;t running on this device.
             </div>
           )}
@@ -125,15 +134,15 @@ export function WelcomePage() {
       </section>
 
       {/* Install / Sovereign roadmap */}
-      <section id="install" className="max-w-5xl mx-auto px-6 py-16 scroll-mt-16">
-        <h2 className="text-3xl font-semibold text-center mb-2">The sovereign roadmap</h2>
-        <p className="text-text-secondary text-center max-w-xl mx-auto mb-10">
+      <section id="install" className="max-w-5xl mx-auto px-4 sm:px-6 py-12 sm:py-16 scroll-mt-16">
+        <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-2">The sovereign roadmap</h2>
+        <p className="text-text-secondary text-center max-w-xl mx-auto mb-8 sm:mb-10">
           .HMAN is incremental. Each phase closes one more gate between you and someone else&rsquo;s cloud.
         </p>
 
-        <div className="grid md:grid-cols-2 gap-6">
+        <div className="grid md:grid-cols-2 gap-4 sm:gap-6">
           {/* Desktop */}
-          <div className="rounded-xl border border-border bg-background-secondary p-8">
+          <div className="rounded-xl border border-border bg-background-secondary p-6 sm:p-8">
             <div className="flex items-center gap-3 mb-4">
               <div className="p-2.5 rounded-lg bg-blue-500/10 text-blue-400">
                 <MonitorDown className="w-6 h-6" />
@@ -196,7 +205,7 @@ cd apps/web-dashboard && npm run dev`}
           </div>
 
           {/* Phone */}
-          <div className="rounded-xl border border-border bg-background-secondary p-8">
+          <div className="rounded-xl border border-border bg-background-secondary p-6 sm:p-8">
             <div className="flex items-center gap-3 mb-4">
               <div className="p-2.5 rounded-lg bg-purple-500/10 text-purple-400">
                 <Smartphone className="w-6 h-6" />
@@ -233,7 +242,7 @@ cd apps/web-dashboard && npm run dev`}
 
             <button
               disabled
-              className="w-full px-4 py-2.5 rounded-lg border border-border bg-background text-text-secondary text-sm font-medium cursor-not-allowed opacity-60"
+              className="w-full min-h-11 px-4 py-2.5 rounded-lg border border-border bg-background text-text-secondary text-base font-medium cursor-not-allowed opacity-60"
             >
               Join the waitlist (soon)
             </button>
@@ -242,8 +251,8 @@ cd apps/web-dashboard && npm run dev`}
       </section>
 
       {/* Five gates */}
-      <section className="max-w-5xl mx-auto px-6 py-16">
-        <h2 className="text-3xl font-semibold text-center mb-2">Five guarantees</h2>
+      <section className="max-w-5xl mx-auto px-4 sm:px-6 py-12 sm:py-16">
+        <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-2">Five guarantees</h2>
         <p className="text-text-secondary text-center max-w-xl mx-auto mb-10">
           The architecture enforces these. They aren&rsquo;t promises. They&rsquo;re gates.
           If any gate leaks, you&rsquo;re the product.
@@ -285,8 +294,8 @@ cd apps/web-dashboard && npm run dev`}
       </section>
 
       {/* Quote */}
-      <section className="max-w-3xl mx-auto px-6 py-20 text-center">
-        <p className="text-xl md:text-2xl text-text-primary italic leading-relaxed">
+      <section className="max-w-3xl mx-auto px-4 sm:px-6 py-12 sm:py-20 text-center">
+        <p className="text-lg sm:text-xl md:text-2xl text-text-primary italic leading-relaxed">
           &ldquo;These five gates will tell you if .HMAN is actually working as intended,
           or if it&rsquo;s just another surveillance device wearing a friendly mask.&rdquo;
         </p>
@@ -294,7 +303,7 @@ cd apps/web-dashboard && npm run dev`}
 
       {/* Footer */}
       <footer className="border-t border-border">
-        <div className="max-w-6xl mx-auto px-6 py-10 flex flex-wrap items-center justify-between gap-4 text-sm text-text-secondary">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 sm:py-10 flex flex-wrap items-center justify-between gap-4 text-sm text-text-secondary">
           <div className="flex items-center gap-2">
             <ShieldCheck className="w-4 h-4" />
             <span>.HMAN platform · MIT licensed · built on PACT</span>
@@ -405,31 +414,31 @@ function SubconsciousPreview() {
   }, [tick])
 
   return (
-    <div className="max-w-3xl mx-auto rounded-xl border border-border bg-background-secondary overflow-hidden text-left shadow-2xl">
+    <div className="w-full max-w-3xl mx-auto rounded-xl border border-border bg-background-secondary overflow-hidden text-left shadow-2xl">
       {/* Window chrome */}
-      <div className="px-5 py-3 border-b border-border flex items-center gap-3">
-        <div className="flex items-center gap-1.5">
+      <div className="px-3 sm:px-5 py-3 border-b border-border flex items-center gap-3">
+        <div className="flex items-center gap-1.5 shrink-0">
           <span className="w-3 h-3 rounded-full bg-red-500/60" />
           <span className="w-3 h-3 rounded-full bg-amber-500/60" />
           <span className="w-3 h-3 rounded-full bg-green-500/60" />
         </div>
-        <div className="flex-1 text-center">
-          <span className="text-xs text-text-secondary font-mono">
+        <div className="flex-1 text-center min-w-0">
+          <span className="text-xs text-text-secondary font-mono truncate block">
             hman.example.com/app
           </span>
         </div>
       </div>
 
       {/* Master strip */}
-      <div className="px-5 py-4 border-b border-border flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Power className="w-5 h-5 text-green-400" />
-          <div>
+      <div className="px-3 sm:px-5 py-4 border-b border-border flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Power className="w-5 h-5 text-green-400 shrink-0" />
+          <div className="min-w-0">
             <p className="font-semibold text-text-primary text-sm">Subconscious</p>
             <p className="text-xs text-text-secondary">4 of 4 sensors active</p>
           </div>
         </div>
-        <span className="text-xs px-3 py-1.5 rounded-md bg-background border border-border text-text-secondary">
+        <span className="text-xs px-3 py-1.5 rounded-md bg-background border border-border text-text-secondary shrink-0">
           Stop all
         </span>
       </div>
@@ -439,15 +448,15 @@ function SubconsciousPreview() {
         {PREVIEW_SENSORS.map((s) => {
           const Icon = s.icon
           return (
-            <div key={s.name} className="px-5 py-3 flex items-center gap-4">
+            <div key={s.name} className="px-3 sm:px-5 py-3 flex items-center gap-3 sm:gap-4">
               <div
                 className="h-8 w-8 shrink-0 rounded-lg flex items-center justify-center"
                 style={{ backgroundColor: `${s.color}26`, color: s.color }}
               >
                 <Icon className="w-4 h-4" />
               </div>
-              <div className="w-28 shrink-0">
-                <p className="text-sm font-medium text-text-primary">{s.label}</p>
+              <div className="w-20 sm:w-28 shrink-0 min-w-0">
+                <p className="text-sm font-medium text-text-primary truncate">{s.label}</p>
                 <p className="text-[10px] text-text-secondary leading-tight truncate">
                   {s.chipLabel}
                 </p>
@@ -504,13 +513,13 @@ function Spec({
   const dot =
     tone === 'shipped' ? 'bg-green-400' : 'bg-amber-400'
   return (
-    <div className="flex items-baseline gap-2 text-sm">
+    <div className="flex items-baseline gap-2 text-sm flex-wrap">
       <span
         className={`w-1.5 h-1.5 rounded-full shrink-0 mt-1.5 ${dot}`}
         title={tone === 'shipped' ? 'shipped' : 'planned'}
       />
-      <span className="text-text-secondary min-w-[7rem]">{label}</span>
-      <span className="text-text-primary flex-1">
+      <span className="text-text-secondary min-w-[5rem] sm:min-w-[7rem]">{label}</span>
+      <span className="text-text-primary flex-1 min-w-0 break-words">
         {value}
         {hint && <span className="text-text-secondary text-xs ml-2">({hint})</span>}
       </span>

--- a/apps/web-dashboard/tailwind.config.js
+++ b/apps/web-dashboard/tailwind.config.js
@@ -26,7 +26,37 @@ export default {
           locked: '#ef4444',
         },
       },
+      // iOS notch / home-indicator safe-area utilities. Use as `pt-safe`,
+      // `pb-safe`, `pl-safe`, `pr-safe`, or stack with regular padding e.g.
+      // `pb-[calc(env(safe-area-inset-bottom)+1rem)]`.
+      spacing: {
+        safe: 'env(safe-area-inset-bottom)',
+        'safe-t': 'env(safe-area-inset-top)',
+        'safe-b': 'env(safe-area-inset-bottom)',
+        'safe-l': 'env(safe-area-inset-left)',
+        'safe-r': 'env(safe-area-inset-right)',
+      },
     },
   },
-  plugins: [],
+  plugins: [
+    function ({ addUtilities }) {
+      addUtilities({
+        '.pt-safe': { paddingTop: 'env(safe-area-inset-top)' },
+        '.pb-safe': { paddingBottom: 'env(safe-area-inset-bottom)' },
+        '.pl-safe': { paddingLeft: 'env(safe-area-inset-left)' },
+        '.pr-safe': { paddingRight: 'env(safe-area-inset-right)' },
+        '.px-safe': {
+          paddingLeft: 'env(safe-area-inset-left)',
+          paddingRight: 'env(safe-area-inset-right)',
+        },
+        '.py-safe': {
+          paddingTop: 'env(safe-area-inset-top)',
+          paddingBottom: 'env(safe-area-inset-bottom)',
+        },
+        '.mb-safe': { marginBottom: 'env(safe-area-inset-bottom)' },
+        '.mt-safe': { marginTop: 'env(safe-area-inset-top)' },
+        '.bottom-safe': { bottom: 'env(safe-area-inset-bottom)' },
+      })
+    },
+  ],
 }


### PR DESCRIPTION
Fixes #10.

Audits every page in `apps/web-dashboard/src/pages/` for iPhone-class viewports (390-430 wide), preparing the member app for the PWA install tracked in #8.

## Patterns applied
- **No overflow at 390px**: replaced fixed widths with `w-full`/`max-w-*`, added `flex-wrap`, `min-w-0`, `truncate`/`break-words`/`break-all` on long text, paired-down inline label widths.
- **Touch targets >= 44px**: added `min-h-11` (and `min-w-11` for icon-only buttons) to every interactive control. Toggle switches wrapped in 44x44 buttons with `aria-label`.
- **Body type >= 16px**: removed `text-sm` from inputs / selects / textareas (it triggers iOS auto-zoom on focus). Switched primary CTAs to `text-base`.
- **Tables -> cards below `md`**: `AuditPage` now renders a 4-column table on `md+` and a vertical card list on smaller screens.
- **Safe-area insets**: added `pt-safe`, `pb-safe`, `pl-safe`, `pr-safe` Tailwind utilities backed by `env(safe-area-inset-*)`. Applied to `Layout` root and the new bottom tab bar so the home indicator does not eat tap area on iPhone.

## Layout
- Side nav collapses to a fixed **bottom tab bar** below `md` (replaces the previous hamburger drawer). The tab bar respects `env(safe-area-inset-bottom)`.
- Mobile header reduced to brand-only (no menu button needed).
- Main content gets `pb-24 md:pb-6` so content does not sit under the tab bar.

## Tailwind
`tailwind.config.js`: added a small plugin that registers `pt-safe` / `pb-safe` / `pl-safe` / `pr-safe` / `px-safe` / `py-safe` / `mb-safe` / `bottom-safe` utilities. No new dependencies.

## Per-page summary
- **WelcomePage**: hero typography scales down on mobile, preview-row label width tightens, header nav buttons hit 44px, root padded with safe-area on all four sides.
- **OnboardingPage**: passphrase inputs and primary buttons all `min-h-11 text-base`. Prompt line wraps. Recording-control row uses `flex-wrap`.
- **DashboardPage**: heading scales, refresh icon button gains 44px target, gates row stacks detail under name on narrow screens.
- **GatesPage**: gate-5 arm/disarm buttons enlarged. Arm modal input + buttons sized for touch.
- **VaultsPage**: card more-button now always visible on mobile (was `opacity-0 group-hover:opacity-100`, broken on touch). Search input `text-base`.
- **MemoryPage**: heading and refresh button sized, list rows wrap and break-word, monospace path uses `break-all`.
- **AuditPage**: split into `hidden md:block` desktop table + `md:hidden space-y-3` mobile cards. Filter chip rail height >= 44px.
- **SettingsPage**: section nav becomes horizontal-scroll chip rail below `lg`. Inputs/selects all `text-base min-h-11`. All four toggles wrapped in 44x44 button hosts (originally 24x44).
- **SubconsciousPage**: master strip stacks vertically with full-width primary action below `sm`. Per-sensor row wraps and toggle button >= 44px. Sparkline container `overflow-hidden`.
- **DelegationsPage**: pending and active rows wrap. Action buttons (Edit, Revoke, Resend, Copy, Trash) >= 44px. Invite modal padded with `p-4`, inputs/selects `text-base`.
- **RequestsPage**: filter chip rail full-width-bleeds on mobile, Approve/Deny buttons `min-h-11 text-base`.

## Validation
- `tsc --noEmit` clean.
- `vite build` succeeds.
- **Visual verification on a real iPhone is a manual step the reviewer should do post-merge.** Recommended viewports: iPhone SE (375), iPhone 13/14 (390), iPhone 14 Pro Max (430). Check landscape too — bottom tab bar must clear the home indicator.

## Constraints respected
- Aesthetic preserved (this is an audit, not a redesign).
- No business logic touched.
- No new runtime dependencies.