### PR TITLE
feat(ios): AirPods + Core Motion sensors

### DIFF
--- a/apps/ios/Sources/HMAN/Info.plist
+++ b/apps/ios/Sources/HMAN/Info.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  HMAN iOS Info.plist
+  ───────────────────
+
+  Capabilities and permissions for Wave 2 sensor work (#14).
+
+  • UIBackgroundModes
+      • audio       — `AVAudioEngine` keeps tapping the input node when the
+                      screen is locked. Required for the always-on ambient
+                      buffer that feeds the receptivity gate.
+      • processing  — periodic background tasks (vault sync, bridge keep-
+                      alive). Hooked up in a later sub-issue, declared here
+                      so we don't need a fresh provisioning round trip later.
+
+  • NSMicrophoneUsageDescription
+      Member-facing string. Shown by iOS the first time we activate the
+      audio session. The wording is intentionally honest about what we do
+      with the audio (kept locally, transcribed only on demand). Don't
+      shorten it without running it past the privacy review.
+
+  • NSMotionUsageDescription
+      Required for `CMHeadphoneMotionManager`. The string explains the
+      consent loop — head-shake / head-nod becomes the gesture for replying
+      to receptivity prompts.
+
+  • NSBluetoothAlwaysUsageDescription
+      Reserved for the future MFi-route-detail work. AirPods route changes
+      themselves are observable without a Bluetooth permission, but if a
+      later PR wants the precise BT peripheral metadata we want the string
+      already shipped.
+
+  Future sub-issues (#16 HealthKit, #17 APNs, #18 voice biometric) will add
+  their own keys here — keep alphabetical order within `<dict>`.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>HMAN</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>HMAN</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>HMAN reads which audio route is active (e.g. AirPods) so the receptivity gate can decide when it's appropriate to speak. We don't pair, scan for, or store data about other Bluetooth devices.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>HMAN listens to short ambient samples (held only in memory, never written to disk) so the receptivity gate can tell whether you're in a moment that's worth surfacing — and only sends a transcript to your local bridge when you've consented.</string>
+    <key>NSMotionUsageDescription</key>
+    <string>HMAN reads AirPods head motion so a head-shake or head-nod can be a private "no" or "yes" reply to the gate's prompts. Motion data is processed on-device and never leaves your phone.</string>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>audio</string>
+        <string>processing</string>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/apps/ios/Sources/HMAN/Sensors/AirPodsPresence.swift
+++ b/apps/ios/Sources/HMAN/Sensors/AirPodsPresence.swift
@@ -1,0 +1,101 @@
+// AirPodsPresence.swift — in-ear / headphones-route signal for the receptivity gate.
+//
+// AirPods (and most BT headphones with a microphone) advertise themselves as a
+// new audio route on `AVAudioSession.sharedInstance().currentRoute`. We don't
+// get a true "in-ear" boolean from CoreBluetooth without MFi entitlements, so
+// we infer it: if the *current input* is an AirPods/BT-HFP route OR the
+// *current output* is an AirPods/headphones route, treat as `inEar`.
+//
+// This is intentionally conservative — false positives (BT speaker counted as
+// "headphones") are fine for the receptivity gate; the gate composes this with
+// motion + ambient RMS before deciding to surface anything.
+//
+// Wire-up: `RECEPTIVITY_INPUTS` owns the singleton; SwiftUI views observe via
+// `@EnvironmentObject`. The publisher fires on `AVAudioSession.routeChangeNotification`
+// — the same notification iOS posts when AirPods are taken out of the ear (the
+// system pauses media; the route change reports the previous route).
+
+import Foundation
+import Combine
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+public final class AirPodsPresence: ObservableObject, @unchecked Sendable {
+    /// True when the audio session's current route looks like in-ear / on-ear
+    /// headphones (wired or BT). Inferred — see file header.
+    @Published public private(set) var inEar: Bool = false
+
+    /// True when *any* headphone-shaped route is active, even if we can't be
+    /// sure about in-ear vs over-ear (e.g. AirPods Max). Useful for the
+    /// receptivity gate's coarser checks.
+    @Published public private(set) var headphonesActive: Bool = false
+
+    /// Human-readable description of the current route, for debug surfaces and
+    /// the audit log. Format: `"<port-name> (<port-type>)"` joined by `" + "`.
+    @Published public private(set) var routeDescription: String = ""
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    public init() {
+        #if canImport(AVFoundation) && !os(macOS)
+        // Initial snapshot — covers the case where AirPods were already
+        // connected when the app launched.
+        refresh()
+
+        // `routeChangeNotification` is delivered on whichever queue posted
+        // the notification (typically a system audio queue). We force-hop
+        // to `RunLoop.main` so `@Published` mutations stay on the main
+        // thread.
+        NotificationCenter.default
+            .publisher(for: AVAudioSession.routeChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        #endif
+    }
+
+    /// Force a re-read. Tests use this; production code triggers via the
+    /// notification subscription.
+    public func refresh() {
+        #if canImport(AVFoundation) && !os(macOS)
+        let route = AVAudioSession.sharedInstance().currentRoute
+        let outputs = route.outputs
+        let inputs = route.inputs
+
+        let outputHeadphones = outputs.contains { Self.isHeadphoneLike($0.portType) }
+        let inputHeadphones = inputs.contains { Self.isHeadphoneLike($0.portType) }
+
+        self.headphonesActive = outputHeadphones || inputHeadphones
+        // We treat any headphone route as in-ear-equivalent for gating.
+        // A future refinement: parse `AVAudioSession.outputDataSource` /
+        // CoreBluetooth descriptors to disambiguate AirPods Max (on-ear)
+        // vs Pro/3 (in-ear). Not needed for the current gate.
+        self.inEar = self.headphonesActive
+
+        let descriptors = outputs.map { "\($0.portName) (\($0.portType.rawValue))" }
+            + inputs.map { "in:\($0.portName) (\($0.portType.rawValue))" }
+        self.routeDescription = descriptors.joined(separator: " + ")
+        #else
+        // Non-iOS host (tests on macOS / Linux): keep current values.
+        #endif
+    }
+
+    #if canImport(AVFoundation) && !os(macOS)
+    /// Port types we count as "headphones-like". Kept narrow on purpose —
+    /// e.g. CarPlay / built-in mic explicitly *don't* qualify.
+    private static func isHeadphoneLike(_ port: AVAudioSession.Port) -> Bool {
+        switch port {
+        case .headphones,           // wired
+             .bluetoothA2DP,        // most BT music output (AirPods media)
+             .bluetoothHFP,         // BT call profile (AirPods mic)
+             .bluetoothLE,          // BT-LE audio
+             .airPlay,              // AirPlay-routed
+             .usbAudio:             // wired USB-C 'pods
+            return true
+        default:
+            return false
+        }
+    }
+    #endif
+}

--- a/apps/ios/Sources/HMAN/Sensors/AmbientAudio.swift
+++ b/apps/ios/Sources/HMAN/Sensors/AmbientAudio.swift
@@ -1,0 +1,205 @@
+// AmbientAudio.swift — always-on circular ambient-audio buffer.
+//
+// The "40 words a day" model rests on listening cheaply, transcribing rarely.
+// This file owns the *cheap* half: a 60-second `RingBuffer<Float>` fed by
+// `AVAudioEngine.inputNode.installTap`. Nothing is written to disk. The
+// receptivity gate (#4) borrows the most recent N seconds via `lastWindow`
+// only when it has decided the moment is worth surfacing — at which point
+// the bridge can transcribe the snippet in memory and discard.
+//
+// Background mode: with `UIBackgroundModes = ["audio", "processing"]` and an
+// active audio session in `.record`/`.playAndRecord` category, iOS keeps the
+// tap running while the screen is locked. The manual test plan in the PR
+// description verifies this for 30+ minutes.
+//
+// Threading: the engine's render thread invokes the tap callback off the main
+// actor. We keep the ring buffer behind a lock and only publish derived stats
+// (`@Published var rms`) from `MainActor.run`.
+
+import Foundation
+import Combine
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+/// Generic fixed-capacity ring buffer for `Float` samples. Internally
+/// non-locking — the owner serialises access. Exposed at file scope so other
+/// sensors (EEG-on-iOS, future watch-bridge) can reuse the type.
+public struct RingBuffer<Element> {
+    public private(set) var capacity: Int
+    private var storage: [Element]
+    private var head: Int = 0
+    public private(set) var count: Int = 0
+
+    public init(capacity: Int, fill: Element) {
+        precondition(capacity > 0, "RingBuffer needs positive capacity")
+        self.capacity = capacity
+        self.storage = Array(repeating: fill, count: capacity)
+    }
+
+    public mutating func append(_ value: Element) {
+        storage[head] = value
+        head = (head + 1) % capacity
+        if count < capacity { count += 1 }
+    }
+
+    public mutating func append(contentsOf values: UnsafeBufferPointer<Element>) {
+        for v in values { append(v) }
+    }
+
+    /// Read the last `n` samples in chronological order. If `n` exceeds
+    /// `count`, returns whatever is available.
+    public func suffix(_ n: Int) -> [Element] {
+        let take = Swift.min(n, count)
+        guard take > 0 else { return [] }
+        var out: [Element] = []
+        out.reserveCapacity(take)
+        let start = (head - take + capacity) % capacity
+        for i in 0..<take {
+            out.append(storage[(start + i) % capacity])
+        }
+        return out
+    }
+
+    public var allSamples: [Element] { suffix(count) }
+}
+
+/// Always-on ambient-audio capture. Not `@MainActor`-isolated — the engine's
+/// tap callback fires on a render thread and we need to push samples into the
+/// ring buffer from there. `@Published` mutations are hopped to the main
+/// queue explicitly via `DispatchQueue.main.async`.
+public final class AmbientAudio: ObservableObject, @unchecked Sendable {
+    /// Most recent root-mean-square level over the last ~50ms tap, normalised
+    /// to roughly `[0, 1]`. The receptivity gate uses this as a coarse
+    /// "is something happening" signal.
+    @Published public private(set) var rms: Float = 0
+
+    /// True while the engine is running and tapping the input node.
+    @Published public private(set) var isCapturing: Bool = false
+
+    /// Human-readable last error, surfaced to the debug view. We don't throw
+    /// from `start()` because the receptivity gate must keep working even if
+    /// audio capture fails (no permission, no input device, etc.).
+    @Published public private(set) var lastError: String?
+
+    /// Sample rate the engine is running at. Captured on `start()` so
+    /// `lastWindow(seconds:)` can convert correctly.
+    @Published public private(set) var sampleRate: Double = 0
+
+    private let bufferSeconds: Int
+    private let bufferLock = NSLock()
+    private var buffer: RingBuffer<Float>
+
+    #if canImport(AVFoundation) && !os(macOS)
+    private let engine = AVAudioEngine()
+    #endif
+
+    public init(bufferSeconds: Int = 60) {
+        self.bufferSeconds = bufferSeconds
+        // Provisional capacity at 16 kHz; resized on `start()` once we know
+        // the actual hardware sample rate.
+        self.buffer = RingBuffer(capacity: bufferSeconds * 16_000, fill: 0)
+    }
+
+    /// Start capturing. Idempotent. Returns `true` if the engine is running
+    /// after the call (already-running counts as success).
+    @discardableResult
+    public func start() -> Bool {
+        #if canImport(AVFoundation) && !os(macOS)
+        if engine.isRunning { return true }
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .mixWithOthers, .defaultToSpeaker])
+            try session.setActive(true, options: [])
+
+            let input = engine.inputNode
+            let format = input.outputFormat(forBus: 0)
+            // Resize the buffer now we know the real rate.
+            let newCap = max(1, Int(format.sampleRate) * bufferSeconds)
+            bufferLock.lock()
+            self.buffer = RingBuffer(capacity: newCap, fill: 0)
+            bufferLock.unlock()
+
+            input.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buf, _ in
+                self?.consume(buffer: buf)
+            }
+            try engine.start()
+            publishMain {
+                self.sampleRate = format.sampleRate
+                self.isCapturing = true
+                self.lastError = nil
+            }
+            return true
+        } catch {
+            publishMain {
+                self.lastError = String(describing: error)
+                self.isCapturing = false
+            }
+            return false
+        }
+        #else
+        publishMain { self.lastError = "AVAudioEngine unavailable on this platform" }
+        return false
+        #endif
+    }
+
+    public func stop() {
+        #if canImport(AVFoundation) && !os(macOS)
+        guard engine.isRunning else { return }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        publishMain { self.isCapturing = false }
+        #endif
+    }
+
+    /// Hop to the main queue if we aren't already there. `@Published`
+    /// requires main-thread mutation; the engine's render thread does not
+    /// qualify.
+    private func publishMain(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
+        } else {
+            DispatchQueue.main.async(execute: block)
+        }
+    }
+
+    /// Snapshot RMS over the most recent tap callback. Exposed so the
+    /// receptivity gate can poll without subscribing to `$rms`.
+    public func currentRMS() -> Float { rms }
+
+    /// Copy out the last `seconds` of samples in chronological order. Returns
+    /// `[]` when capture isn't running or the buffer is empty.
+    public func lastWindow(seconds: Double) -> [Float] {
+        let n = Int(Double(seconds) * sampleRate)
+        guard n > 0 else { return [] }
+        bufferLock.lock()
+        defer { bufferLock.unlock() }
+        return buffer.suffix(n)
+    }
+
+    // ── Tap callback (engine render thread) ────────────────────────────
+
+    #if canImport(AVFoundation) && !os(macOS)
+    private func consume(buffer pcm: AVAudioPCMBuffer) {
+        guard let channelData = pcm.floatChannelData else { return }
+        let frameCount = Int(pcm.frameLength)
+        let channel0 = UnsafeBufferPointer(start: channelData[0], count: frameCount)
+
+        // Compute RMS off-actor; we only hop to main to publish.
+        var sumSquares: Float = 0
+        for i in 0..<frameCount {
+            let s = channel0[i]
+            sumSquares += s * s
+        }
+        let rmsValue = frameCount > 0 ? (sumSquares / Float(frameCount)).squareRoot() : 0
+
+        // Append into the ring buffer under the lock.
+        bufferLock.lock()
+        buffer.append(contentsOf: channel0)
+        bufferLock.unlock()
+
+        publishMain { self.rms = rmsValue }
+    }
+    #endif
+}
+

--- a/apps/ios/Sources/HMAN/Sensors/HeadGestureDetector.swift
+++ b/apps/ios/Sources/HMAN/Sensors/HeadGestureDetector.swift
@@ -1,0 +1,171 @@
+// HeadGestureDetector.swift — discrete shake / nod detection from AirPods motion.
+//
+// Source of truth is `CMHeadphoneMotionManager`, which streams attitude (roll
+// / pitch / yaw) and rotation rate from AirPods Pro / 3 / Max. We watch for
+// rapid sign-flipping oscillation on a single axis and emit one discrete event
+// per gesture, with debounce so a single physical shake doesn't fire twice.
+//
+// Heuristic — kept simple on purpose; the receptivity gate combines this with
+// AirPods presence and ambient RMS, so we want a low-false-negative detector
+// rather than perfect precision.
+//
+//   • Buffer the last `WINDOW_S` seconds of yaw / pitch rotation rate.
+//   • A shake is `≥ MIN_OSCILLATIONS` zero-crossings of yaw rotation rate
+//     within the window, with peak |rate| ≥ `MIN_PEAK_RAD_PER_S`.
+//   • A nod is the same shape on pitch.
+//   • After firing, refuse to fire again for `DEBOUNCE_S` seconds.
+//
+// Tunables are exposed as `static let` constants prefixed `HEAD_GESTURE_*` so
+// they read like env vars in code review and so the receptivity-gate work
+// (#4) can trivially override them via a config injection later.
+//
+// Threading: `CMHeadphoneMotionManager.startDeviceMotionUpdates(to:)` queues
+// callbacks on whichever `OperationQueue` we hand it. We use `.main` so the
+// `@Published` store and `gestures` subject can be observed on the main actor
+// without further hops. Sample rate is ~50 Hz, well below the actor budget.
+
+import Foundation
+import Combine
+#if canImport(CoreMotion)
+import CoreMotion
+#endif
+
+public enum Gesture: String, Sendable, Equatable {
+    case shake          // horizontal yaw oscillation — semantic "no" / deny
+    case nod            // vertical pitch oscillation — semantic "yes" / confirm
+    case none           // emitted when the detector resets after debounce
+}
+
+/// Detector is *not* main-actor-isolated — `CMHeadphoneMotionManager` calls
+/// us back on whichever `OperationQueue` it's given (we use `.main` so the
+/// callback queue is the main run-loop queue, but Swift concurrency doesn't
+/// infer main-actor isolation from that). `@Published` mutations are hopped
+/// to `DispatchQueue.main` explicitly.
+public final class HeadGestureDetector: ObservableObject, @unchecked Sendable {
+    // ── Tunables (env-var-style names; documented in the file header) ──
+    public static let HEAD_GESTURE_DEBOUNCE_S: TimeInterval = 1.2
+    public static let HEAD_GESTURE_WINDOW_S: TimeInterval = 0.9
+    public static let HEAD_GESTURE_MIN_OSCILLATIONS: Int = 3
+    public static let HEAD_GESTURE_MIN_PEAK_RAD_PER_S: Double = 3.0
+
+    /// Combine stream of detected gestures. Subscribers see one event per
+    /// physical shake/nod; `.none` is emitted when the detector clears the
+    /// debounce window so consumers can reset their UI state if they want.
+    public let gestures = PassthroughSubject<Gesture, Never>()
+
+    /// Last gesture observed, exposed for SwiftUI bindings.
+    @Published public private(set) var lastGesture: Gesture = .none
+
+    /// True while `CMHeadphoneMotionManager` is streaming.
+    @Published public private(set) var isStreaming: Bool = false
+
+    #if canImport(CoreMotion)
+    private let manager: CMHeadphoneMotionManager
+    #endif
+    private var lastFireAt: Date = .distantPast
+    private var yawSamples: [(t: TimeInterval, v: Double)] = []
+    private var pitchSamples: [(t: TimeInterval, v: Double)] = []
+
+    public init() {
+        #if canImport(CoreMotion)
+        self.manager = CMHeadphoneMotionManager()
+        #endif
+    }
+
+    /// Start streaming motion. Safe to call multiple times — re-arms cleanly.
+    public func start() {
+        #if canImport(CoreMotion)
+        guard manager.isDeviceMotionAvailable else {
+            // No AirPods Pro / 3 / Max paired, or the device doesn't support
+            // headphone motion. The receptivity gate falls back gracefully.
+            return
+        }
+        if manager.isDeviceMotionActive {
+            return
+        }
+        manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+            guard let self, let motion else { return }
+            self.consume(motion: motion)
+        }
+        publishMain { self.isStreaming = self.isStreamingNow }
+        #endif
+    }
+
+    public func stop() {
+        #if canImport(CoreMotion)
+        if manager.isDeviceMotionActive {
+            manager.stopDeviceMotionUpdates()
+        }
+        publishMain { self.isStreaming = false }
+        #endif
+    }
+
+    /// Backing accessor — avoids touching the manager from off the main
+    /// queue. Only called immediately after `start*Updates(...)` lands.
+    private var isStreamingNow: Bool {
+        #if canImport(CoreMotion)
+        return manager.isDeviceMotionActive
+        #else
+        return false
+        #endif
+    }
+
+    private func publishMain(_ block: @escaping () -> Void) {
+        if Thread.isMainThread { block() } else { DispatchQueue.main.async(execute: block) }
+    }
+
+    // ── Detection ──────────────────────────────────────────────────────
+
+    #if canImport(CoreMotion)
+    private func consume(motion: CMDeviceMotion) {
+        let now = motion.timestamp
+        let yawRate = motion.rotationRate.z      // around vertical axis → shake
+        let pitchRate = motion.rotationRate.x    // around lateral axis → nod
+
+        yawSamples.append((now, yawRate))
+        pitchSamples.append((now, pitchRate))
+
+        let cutoff = now - Self.HEAD_GESTURE_WINDOW_S
+        yawSamples.removeAll { $0.t < cutoff }
+        pitchSamples.removeAll { $0.t < cutoff }
+
+        // Debounce — never fire twice within DEBOUNCE_S.
+        if Date().timeIntervalSince(lastFireAt) < Self.HEAD_GESTURE_DEBOUNCE_S {
+            return
+        }
+
+        if Self.detect(samples: yawSamples) {
+            fire(.shake)
+        } else if Self.detect(samples: pitchSamples) {
+            fire(.nod)
+        }
+    }
+    #endif
+
+    /// Pure detector — exposed `internal` so tests can hit it directly with
+    /// synthetic samples instead of a real `CMDeviceMotion` stream.
+    static func detect(samples: [(t: TimeInterval, v: Double)]) -> Bool {
+        guard let peak = samples.map({ abs($0.v) }).max(), peak >= HEAD_GESTURE_MIN_PEAK_RAD_PER_S else {
+            return false
+        }
+        var crossings = 0
+        var lastSign = 0
+        for s in samples where abs(s.v) > 0.5 {
+            let sign = s.v > 0 ? 1 : -1
+            if lastSign != 0 && sign != lastSign {
+                crossings += 1
+            }
+            lastSign = sign
+        }
+        return crossings >= HEAD_GESTURE_MIN_OSCILLATIONS
+    }
+
+    private func fire(_ gesture: Gesture) {
+        lastFireAt = Date()
+        gestures.send(gesture)
+        publishMain { self.lastGesture = gesture }
+        // Reset buffers so the next gesture starts from a clean window.
+        yawSamples.removeAll()
+        pitchSamples.removeAll()
+    }
+}

--- a/apps/ios/Sources/HMAN/Sensors/RECEPTIVITY_INPUTS.swift
+++ b/apps/ios/Sources/HMAN/Sensors/RECEPTIVITY_INPUTS.swift
@@ -1,0 +1,113 @@
+// RECEPTIVITY_INPUTS.swift — sensor fan-in for the (future) ReceptivityGate.
+//
+// This file is the seam between Wave 2's sensor PRs (this one, #16 HealthKit,
+// future watch-bridge) and the ReceptivityGate work tracked in #4. Each
+// sensor publishes its own narrow signal; this object aggregates the slice
+// the gate cares about and re-publishes as one `ObservableObject` so the
+// gate, the SwiftUI debug surface, and the bridge-uploader can all subscribe
+// without knowing about every sensor type individually.
+//
+// Naming: the screaming snake-case is intentional — it stands out in the
+// file tree as "this is the public contract surface" rather than yet
+// another model class. Don't rename without coordinating with #4.
+//
+// Threading: `@Published` mutations require the main thread but Swift
+// concurrency's `@MainActor` isolation is intentionally avoided here so
+// callers (SwiftUI views, the gate, tests) can construct the aggregator
+// from any context. Internally every sink uses `.receive(on: RunLoop.main)`
+// so the SwiftUI subscriber contract is preserved.
+
+import Foundation
+import Combine
+
+/// Coarse motion classification. The detector publishes raw gestures; the
+/// gate cares about *state* — "is the head still right now?" Not every
+/// upstream sensor will populate this; the watch-bridge / activity-classifier
+/// PRs fill in the rest.
+public enum MotionState: String, Sendable, Equatable {
+    case still
+    case walking
+    case running
+    case driving
+    case unknown
+}
+
+public final class ReceptivityInputs: ObservableObject, @unchecked Sendable {
+    // ── Inputs the gate currently consumes ─────────────────────────────
+
+    /// True when AirPods (or another headphone-shaped route) is presenting
+    /// audio. Re-published from `AirPodsPresence`.
+    @Published public private(set) var inEar: Bool = false
+
+    /// True when *any* headphone-shaped route is active. Slightly looser
+    /// than `inEar`; the gate uses this when deciding whether to route
+    /// audible TTS replies vs. visual-only.
+    @Published public private(set) var headphonesActive: Bool = false
+
+    /// Coarse motion. `unknown` until the watch-bridge / motion-classifier
+    /// fills it in.
+    @Published public private(set) var motionState: MotionState = .unknown
+
+    /// Last discrete head gesture, if any. `nil` after debounce clears.
+    @Published public private(set) var lastHeadGesture: Gesture? = nil
+
+    /// Last ambient-audio RMS, in `[0, 1]`-ish. Re-published from
+    /// `AmbientAudio`.
+    @Published public private(set) var ambientRMS: Float = 0
+
+    // ── Wiring ─────────────────────────────────────────────────────────
+
+    public let airpods: AirPodsPresence
+    public let gestures: HeadGestureDetector
+    public let ambient: AmbientAudio
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    public init(
+        airpods: AirPodsPresence = AirPodsPresence(),
+        gestures: HeadGestureDetector = HeadGestureDetector(),
+        ambient: AmbientAudio = AmbientAudio()
+    ) {
+        self.airpods = airpods
+        self.gestures = gestures
+        self.ambient = ambient
+
+        airpods.$inEar
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.inEar = $0 }
+            .store(in: &cancellables)
+
+        airpods.$headphonesActive
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.headphonesActive = $0 }
+            .store(in: &cancellables)
+
+        gestures.gestures
+            .receive(on: RunLoop.main)
+            .sink { [weak self] g in self?.lastHeadGesture = (g == .none ? nil : g) }
+            .store(in: &cancellables)
+
+        ambient.$rms
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.ambientRMS = $0 }
+            .store(in: &cancellables)
+    }
+
+    /// Boot all sensors at once. Called from the SwiftUI app on launch
+    /// (after permissions). Safe to call multiple times.
+    public func startAll() {
+        gestures.start()
+        ambient.start()
+    }
+
+    public func stopAll() {
+        gestures.stop()
+        ambient.stop()
+    }
+
+    /// Allow the (future) motion-classifier to push state in. Kept narrow so
+    /// the gate doesn't accidentally couple to `CMMotionActivity`.
+    public func updateMotionState(_ state: MotionState) {
+        self.motionState = state
+    }
+}

--- a/apps/ios/Tests/HMANTests/AirPodsPresenceTests.swift
+++ b/apps/ios/Tests/HMANTests/AirPodsPresenceTests.swift
@@ -1,0 +1,146 @@
+// AirPodsPresenceTests.swift — sensor-layer tests.
+//
+// Most of the AirPods/route-change behaviour is hardware-dependent and only
+// reproducible on a real device. This file covers what we *can* verify in CI
+// (publishers wired up correctly, gesture detector pure logic, ring buffer
+// semantics) and documents the manual matrix for the rest.
+//
+// Manual test plan — run on a device with AirPods Pro (or 3, or Max) before
+// merging into a release branch:
+//
+//   1. Lock phone, walk for 30+ minutes with AirPods in.
+//      Expect: `AmbientAudio.isCapturing` stays true, `rms` keeps updating
+//      in the debug overlay (visible after unlock), no crash on resume.
+//
+//   2. Take one AirPod out mid-session.
+//      Expect: a `routeChange` notification, `inEar` flips false within ~1s,
+//      then back to true when reseated.
+//
+//   3. With AirPods in, shake head left-right sharply 3+ times.
+//      Expect: `gestures` subject emits `.shake` once (not twice).
+//      Repeat with vertical nod — expect `.nod`.
+//
+//   4. Background the app, leave it for >5 minutes, foreground.
+//      Expect: ambient buffer still has fresh samples (`lastWindow(seconds: 5)`
+//      returns non-zero count); no microphone-permission re-prompt.
+//
+// Anything failing → file a follow-up issue with the logs from the debug
+// view, don't block the PR on a flake.
+
+import XCTest
+import Combine
+@testable import HMAN
+
+final class AirPodsPresenceTests: XCTestCase {
+    func testInitialPublishersAreReadable() {
+        let presence = AirPodsPresence()
+        // We can't assert the boolean value (depends on the host's audio
+        // route, which is non-deterministic in CI). We *can* assert the
+        // publisher fires synchronously on subscription, which proves the
+        // wiring isn't broken.
+        var observedInEar: Bool?
+        var observedHeadphones: Bool?
+        let c1 = presence.$inEar.sink { observedInEar = $0 }
+        let c2 = presence.$headphonesActive.sink { observedHeadphones = $0 }
+        XCTAssertNotNil(observedInEar)
+        XCTAssertNotNil(observedHeadphones)
+        XCTAssertEqual(observedInEar, presence.inEar)
+        XCTAssertEqual(observedHeadphones, presence.headphonesActive)
+        c1.cancel(); c2.cancel()
+    }
+
+    func testRefreshIsIdempotent() {
+        let presence = AirPodsPresence()
+        let before = presence.routeDescription
+        presence.refresh()
+        presence.refresh()
+        let after = presence.routeDescription
+        // Either both empty (no host audio) or stably equal — never partially
+        // populated between calls.
+        XCTAssertEqual(before, after)
+    }
+}
+
+final class HeadGestureDetectorTests: XCTestCase {
+    /// Synthetic shake: alternating-sign yaw rate at well above the peak
+    /// threshold. Should be detected.
+    func testDetectFiresOnRapidOscillation() {
+        let now: TimeInterval = 0
+        var samples: [(t: TimeInterval, v: Double)] = []
+        // 12 samples, alternating ±5 rad/s — clear oscillation, well above
+        // the 3 rad/s peak threshold.
+        for i in 0..<12 {
+            let v: Double = (i.isMultiple(of: 2) ? 5.0 : -5.0)
+            samples.append((now + Double(i) * 0.05, v))
+        }
+        XCTAssertTrue(HeadGestureDetector.detect(samples: samples))
+    }
+
+    /// Synthetic stillness: all near-zero samples → must not fire.
+    func testDetectIgnoresStillness() {
+        let samples: [(t: TimeInterval, v: Double)] = (0..<20).map {
+            ($0.timeIntervalForTest, 0.05)
+        }
+        XCTAssertFalse(HeadGestureDetector.detect(samples: samples))
+    }
+
+    /// Synthetic single push: large but unidirectional. No oscillation → no
+    /// gesture (avoids false-firing on reaching for the phone).
+    func testDetectIgnoresUnidirectionalMotion() {
+        let samples: [(t: TimeInterval, v: Double)] = (0..<10).map {
+            ($0.timeIntervalForTest, 6.0)
+        }
+        XCTAssertFalse(HeadGestureDetector.detect(samples: samples))
+    }
+}
+
+final class AmbientAudioRingBufferTests: XCTestCase {
+    func testRingBufferWrapsAndPreservesOrder() {
+        var rb = RingBuffer<Float>(capacity: 4, fill: 0)
+        rb.append(1)
+        rb.append(2)
+        rb.append(3)
+        rb.append(4)
+        rb.append(5) // overwrites 1
+        XCTAssertEqual(rb.suffix(4), [2, 3, 4, 5])
+        XCTAssertEqual(rb.suffix(2), [4, 5])
+        XCTAssertEqual(rb.count, 4)
+    }
+
+    func testRingBufferShortReadDoesNotCrash() {
+        var rb = RingBuffer<Float>(capacity: 4, fill: 0)
+        rb.append(1)
+        rb.append(2)
+        XCTAssertEqual(rb.suffix(10), [1, 2])
+        XCTAssertEqual(rb.suffix(0), [])
+    }
+}
+
+final class ReceptivityInputsTests: XCTestCase {
+    func testGesturePropagatesToAggregator() {
+        let inputs = ReceptivityInputs()
+        XCTAssertNil(inputs.lastHeadGesture)
+        // Manually push a gesture through the detector's subject; this is
+        // the same path the real motion callback takes.
+        inputs.gestures.gestures.send(.shake)
+        // Combine `RunLoop.main` delivery — drain a tick.
+        let exp = expectation(description: "gesture delivered")
+        DispatchQueue.main.async {
+            XCTAssertEqual(inputs.lastHeadGesture, .shake)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    func testMotionStateUpdate() {
+        let inputs = ReceptivityInputs()
+        XCTAssertEqual(inputs.motionState, .unknown)
+        inputs.updateMotionState(.walking)
+        XCTAssertEqual(inputs.motionState, .walking)
+    }
+}
+
+private extension Int {
+    /// Spaced-by-50ms timestamp for the synthetic-sample tests.
+    var timeIntervalForTest: TimeInterval { Double(self) * 0.05 }
+}


### PR DESCRIPTION
Fixes #14. Stacked on #28 — please merge #28 first.

## Files added

- **`apps/ios/Sources/HMAN/Sensors/AirPodsPresence.swift`** — wraps
  `AVAudioSession.routeChangeNotification`. Publishes `inEar`,
  `headphonesActive`, `routeDescription`. Treats any wired/BT headphone-
  shaped route as in-ear-equivalent (the gate composes this with motion +
  RMS, so loose-precision is fine).
- **`apps/ios/Sources/HMAN/Sensors/HeadGestureDetector.swift`** — uses
  `CMHeadphoneMotionManager`. Watches yaw rotation rate (shake) and pitch
  rotation rate (nod) for rapid sign-flipping oscillation in a sliding
  window. Tunables: `HEAD_GESTURE_DEBOUNCE_S` (1.2s),
  `HEAD_GESTURE_WINDOW_S` (0.9s), `HEAD_GESTURE_MIN_OSCILLATIONS` (3),
  `HEAD_GESTURE_MIN_PEAK_RAD_PER_S` (3.0). Emits a Combine
  `PassthroughSubject<Gesture, Never>` of `.shake`, `.nod`, `.none`.
- **`apps/ios/Sources/HMAN/Sensors/AmbientAudio.swift`** — `AVAudioEngine`
  input tap → 60-second `RingBuffer<Float>`. Never persisted to disk.
  Exposes `currentRMS()` and `lastWindow(seconds:)` so the receptivity
  gate can borrow a transcription snippet in memory and discard.
- **`apps/ios/Sources/HMAN/Sensors/RECEPTIVITY_INPUTS.swift`** —
  `ReceptivityInputs` ObservableObject aggregator. Owns one of each sensor
  and re-publishes `inEar`, `headphonesActive`, `motionState`,
  `lastHeadGesture`, `ambientRMS` as a single subscription surface for
  the future `ReceptivityGate` (#4).
- **`apps/ios/Sources/HMAN/Info.plist`** — new file. Adds:
  - `UIBackgroundModes`: `audio`, `processing`
  - `NSMicrophoneUsageDescription`
  - `NSMotionUsageDescription`
  - `NSBluetoothAlwaysUsageDescription` (reserved for future MFi work)
- **`apps/ios/Tests/HMANTests/AirPodsPresenceTests.swift`** — pure-logic
  unit tests + ring-buffer wrap test + manual test plan in the file
  header.

`Package.swift` is unchanged — `AVFoundation`, `CoreMotion`, `Combine` are
all stdlib frameworks, no new SPM deps needed.

## How `ReceptivityGate` (#4) will subscribe

The gate gets a single `ReceptivityInputs` instance from the SwiftUI
environment and either:
- observes `@Published` properties via `objectWillChange` / `$inEar` etc.,
  for reactive composition; or
- polls `currentRMS()` / `lastWindow(seconds:)` on demand when it has
  decided to surface something.

`startAll()` boots `HeadGestureDetector` and `AmbientAudio` together;
`AirPodsPresence` is always-on (route-change notifications cost nothing).

## Manual test plan

Documented in the test file header. Summary:
1. Lock phone, walk 30+ minutes with AirPods → `isCapturing` stays true,
   `rms` keeps updating.
2. Take an AirPod out → `inEar` flips false within ~1s.
3. Shake head 3+ times → `gestures` emits `.shake` exactly once.
4. Background app for 5+ min → fresh samples in `lastWindow(seconds: 5)`.

## Out of scope (per issue)

- Apple Watch motion
- On-device transcription (depends on #12 LLM eval)
- Voice biometric on the captured audio (separate Wave 2 issue)
- Persistent storage of ambient audio