### PR TITLE
feat(connectors): PACT-GitHub connector

### DIFF
--- a/docs/demos/github-connector-loop.md
+++ b/docs/demos/github-connector-loop.md
@@ -1,0 +1,267 @@
+# PACT-GitHub connector — end-to-end loop
+
+This walks through the first concrete external action HMAN takes on a member's
+behalf: speak a bug into the room → subconscious drafts an issue → receptivity
+gate decides when to surface it → on consent Y, an authorized member action
+lands on GitHub with a verifiable PACT attestation.
+
+The same shape is the template for every future connector (Bank, Tailor,
+Calendar). Get this loop right; everything else inherits.
+
+## Prerequisites
+
+1. Bridge running on `localhost:8765` (see `DEPLOYMENT.md`).
+2. Voice enrolled (Gate 5) and *armed* (`/api/gate5/unlock`). The connector
+   re-checks Gate 5 freshness on every draft and execute.
+3. Local Ollama (or compatible OpenAI-style chat endpoint) reachable at
+   `HMAN_LLM_ENDPOINT` (default `http://localhost:11434/api/chat`) with a model
+   named in `HMAN_LLM_MODEL` (default `llama3.2:3b`).
+4. A fine-grained GitHub PAT in `HMAN_GITHUB_TOKEN` with **only**
+   `issues:write` on the whitelisted repos. Never use a classic `repo` token —
+   the blast radius is too large.
+
+### Minimum env
+
+```bash
+export HMAN_GITHUB_TOKEN="github_pat_..."
+export HMAN_GITHUB_DEFAULT_OWNER="your-org"
+export HMAN_GITHUB_DEFAULT_REPO="your-repo"
+export HMAN_GITHUB_ALLOWED_REPOS="your-org/your-repo,your-org/other-repo"
+```
+
+`HMAN_GITHUB_ALLOWED_REPOS` is a hard whitelist — if the LLM somehow picks an
+owner/repo not in the list, `execute` returns a structured error and never
+calls GitHub.
+
+### Token onboarding (once per machine)
+
+1. Visit `https://github.com/settings/personal-access-tokens/new`.
+2. **Resource owner**: pick the org the issues will be filed against.
+3. **Repository access**: *Only select repositories* → check exactly the repos
+   in `HMAN_GITHUB_ALLOWED_REPOS`.
+4. **Repository permissions** → *Issues* → *Read and write*. Leave everything
+   else as *No access*.
+5. Expiration: 90 days max. Calendar a rotation reminder.
+6. Copy the token, paste into `bridge.env` (or your shell rc):
+   `HMAN_GITHUB_TOKEN=github_pat_...`. Restart the bridge.
+
+The bridge stores the token only in process memory. Rotation is a restart.
+
+## End-to-end flow
+
+```
+Voice agent (in conversation)
+  "...this Muse handshake is annoying, presets keep returning rc:69..."
+        ↓
+LLM drafts {title, body} from the transcript snippet
+        ↓
+HMAN packages an Intention { connector: "github", action: "issue.create",
+                             payload: { owner, repo, title, body },
+                             urgency: 0.3, context: "<transcript>" }
+        ↓
+intention persisted to ~/.hman/connector_intentions/<id>.json
+        ↓
+receptivity gate (#4) ticks: (score, channel) → ("surface_now", "voice"|"text")
+        ↓
+on surface_now: voice agent says "drafted an issue about the Muse — file it?"
+        ↓
+member: "Y" (voice biometric verified) or taps Y in Signal
+        ↓
+PACT signs attestation: {member_id, intention_hash, channel, timestamp, sig}
+        ↓
+bridge calls gh API: POST /repos/{owner}/{repo}/issues with body containing
+        { ...payload, attestation: <collapsed details block> }
+        ↓
+issue URL appended to ~/.hman/logs/connector_events.jsonl
+        ↓
+member optionally hears "filed, link is in your queue"
+```
+
+## Per-step curl recipes
+
+You'll want to test each step independently while wiring up new clients.
+Replace `$T` with your bridge bearer token (`HMAN_AUTH_TOKEN`) and `$ID` with
+the intention id returned by the draft step.
+
+### 0. Confirm Gate 5 is armed and recently active
+
+```bash
+curl -sS -H "Authorization: Bearer $T" http://127.0.0.1:8765/api/gate5/status | jq
+```
+
+You need `armed: true` and a `last_activation` within the last 60s. If
+`last_activation` is older, hit `/api/gate5/verify` with a fresh utterance to
+refresh the freshness window before drafting.
+
+### 1. Draft an Intention
+
+```bash
+curl -sS -X POST http://127.0.0.1:8765/api/connectors/github/draft \
+  -H "Authorization: Bearer $T" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "context": "the muse handshake is failing — presets keep coming back rc:69 and EEG never starts streaming"
+  }' | jq
+```
+
+Response (camelCase JSON, 200 OK):
+
+```json
+{
+  "id": "f6c9a3b2-...",
+  "connector": "github",
+  "action": "issue.create",
+  "payload": {
+    "owner": "your-org",
+    "repo": "your-repo",
+    "title": "Muse handshake fails: presets return rc:69, EEG never streams",
+    "body": "The Muse handshake fails repeatedly. ... ## Context\n\n> the muse handshake is failing — presets keep coming back rc:69 and EEG never starts streaming"
+  },
+  "description": "File a GitHub issue: \"Muse handshake fails: presets return rc:69, EEG never streams\"",
+  "urgency": 0.3,
+  "context": "the muse handshake is failing ...",
+  "draftedAt": "2026-04-26T12:34:56.789012+00:00"
+}
+```
+
+The intention is now in `~/.hman/connector_intentions/<id>.json`. The dashboard
+RequestsPage will pick it up on next render.
+
+### 2. Ask the receptivity gate when to surface it
+
+```bash
+curl -sS -X POST http://127.0.0.1:8765/api/receptivity/evaluate \
+  -H "Authorization: Bearer $T" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "intention": {
+      "id": "f6c9a3b2-...",
+      "description": "File a GitHub issue: ...",
+      "urgency": "low",
+      "estimated_voice_words": 18
+    }
+  }' | jq
+```
+
+Response:
+
+```json
+{
+  "surface_now": true,
+  "channel": "text",
+  "reason": "Drafted: File a GitHub issue: \"Muse handshake fails ...\"",
+  "score": 0.71,
+  "budget_words_remaining": 22,
+  "budget_interruptions_today": 1
+}
+```
+
+The gate decides — the connector never surfaces itself. `channel="queue"`
+means hold; `text` means whisper via Signal; `voice` means whisper aloud.
+
+### 3. Member consents → execute
+
+```bash
+curl -sS -X POST http://127.0.0.1:8765/api/connectors/github/execute \
+  -H "Authorization: Bearer $T" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "intentionId": "f6c9a3b2-...",
+    "channel": "voice",
+    "member_id": "member"
+  }' | jq
+```
+
+Response (200 OK):
+
+```json
+{
+  "success": true,
+  "artifactUrl": "https://github.com/your-org/your-repo/issues/123",
+  "artifactId": "your-org/your-repo#123",
+  "attestation": {
+    "memberId": "member",
+    "intentionHash": "e62c780a1b...",
+    "channel": "voice",
+    "timestamp": "2026-04-26T12:35:42.111+00:00",
+    "publicKey": "<base64 PEM>",
+    "signature": "<base64 ed25519>"
+  },
+  "error": null
+}
+```
+
+The issue body on GitHub will end with a collapsed `<details>` block:
+
+````markdown
+... LLM body ...
+
+<!-- HMAN PACT attestation — verifies this issue was an authorized member action. -->
+<details>
+<summary>HMAN PACT attestation</summary>
+
+```json
+{
+  "memberId": "member",
+  "intentionHash": "e62c780a1b...",
+  "channel": "voice",
+  "timestamp": "2026-04-26T12:35:42.111+00:00",
+  "publicKey": "...",
+  "signature": "..."
+}
+```
+
+_Verify this signature with the public key above against the canonical hash of the issue payload._
+</details>
+````
+
+Anyone reading the issue can recompute the canonical hash from the issue
+title + body (stripped of the attestation block) and verify the signature with
+the embedded public key. No HMAN-side service is needed to verify.
+
+### 4. Member changes mind → undo
+
+```bash
+# the connector also exposes a programmatic undo path
+curl -sS -X DELETE http://127.0.0.1:8765/api/connectors/github/intentions/$ID \
+  -H "Authorization: Bearer $T"
+```
+
+For an *executed* intention (the issue is already up), HMAN closes the issue
+with a "rescinded by member" comment. The original PACT attestation in the
+body remains as a public history of the authorized action — undo doesn't
+falsify the record.
+
+### 5. Audit
+
+Every step appends a line to `~/.hman/logs/connector_events.jsonl`:
+
+```json
+{"ts": "...", "event": "drafted",  "intention_id": "f6c...", "connector": "github", "extra": {...}}
+{"ts": "...", "event": "decided",  "intention_id": "f6c...", "connector": "github", "channel": "voice", "extra": {"decision": "execute"}}
+{"ts": "...", "event": "executed", "intention_id": "f6c...", "connector": "github", "channel": "voice", "artifact_url": "https://github.com/.../issues/123"}
+```
+
+`tail -f ~/.hman/logs/connector_events.jsonl | jq` while running through the
+demo to watch the lifecycle in real time.
+
+## What can go wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 Gate 5 not fresh` on draft | Last Gate-5 activation > 60s ago | Speak something — `/api/gate5/verify` refreshes |
+| `503 Gate 5 freshness check not configured` | Bridge started without registering the check | Restart bridge — `server.py` wires it on import |
+| `error: HMAN_GITHUB_TOKEN not set` | Token missing or empty | Set `HMAN_GITHUB_TOKEN`, restart bridge |
+| `error: repo X/Y not in allowed_repos whitelist` | LLM picked a repo outside the whitelist | Check `HMAN_GITHUB_ALLOWED_REPOS` |
+| `error: attestation/intention hash mismatch` | Intention was modified after signing | Don't mutate Intentions between draft and execute |
+| `error: GitHub issue create failed: 401` | PAT expired or revoked | Rotate the token |
+| `error: GitHub issue create failed: 403` | PAT scope insufficient | Re-create PAT with `Issues: Read and write` |
+
+## Cross-language verification
+
+The TypeScript `@hman/core` package exports the same hashing and attestation
+helpers (`hashIntention`, `signAttestation`, `renderAttestationBlock`). Hashes
+computed in TS and Python over the same Intention are byte-for-byte identical
+(SHA-256 over a canonical JSON encoding with stable key order and minimal
+separators). A browser or Node consumer can verify a PACT attestation produced
+by the Python bridge — and vice versa — without HMAN-specific tooling.

--- a/packages/core/src/__tests__/connectors.test.ts
+++ b/packages/core/src/__tests__/connectors.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Connector tests — every behavior the contract promises:
+ *  - draft turns context into a typed Intention
+ *  - hashIntention is deterministic
+ *  - signAttestation produces a verifiable Ed25519 signature
+ *  - execute embeds the attestation block in the issue body
+ *  - execute rejects mismatched attestations and disallowed repos
+ *  - undo closes the issue with a comment
+ *  - LLM stub fallback survives malformed model output
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'crypto';
+import {
+  GitHubConnector,
+  hashIntention,
+  parseDraftReply,
+  renderAttestationBlock,
+  signAttestation,
+} from '../connectors/github.js';
+import type { GitHubClient, LLMClient } from '../connectors/types.js';
+import type { Intention, PACTAttestation } from '../connectors/Connector.js';
+
+class StubLLM implements LLMClient {
+  constructor(private readonly reply: string) {}
+  async chat(): Promise<string> {
+    return this.reply;
+  }
+}
+
+class StubGitHub implements GitHubClient {
+  public lastCreate: { owner: string; repo: string; title: string; body: string } | undefined;
+  public lastClose: { owner: string; repo: string; issue_number: number; comment?: string } | undefined;
+  constructor(
+    private readonly createResult: { number: number; html_url: string } = {
+      number: 42,
+      html_url: 'https://github.com/example/repo/issues/42',
+    },
+    private readonly throwOnCreate: Error | null = null,
+  ) {}
+  async createIssue(input: {
+    owner: string;
+    repo: string;
+    title: string;
+    body: string;
+  }): Promise<{ number: number; html_url: string }> {
+    if (this.throwOnCreate) throw this.throwOnCreate;
+    this.lastCreate = input;
+    return this.createResult;
+  }
+  async closeIssue(input: {
+    owner: string;
+    repo: string;
+    issue_number: number;
+    comment?: string;
+  }): Promise<void> {
+    this.lastClose = input;
+  }
+}
+
+function freshKeypair(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }) as string,
+  };
+}
+
+describe('hashIntention', () => {
+  const base: Intention<unknown> = {
+    id: 'i1',
+    connector: 'github',
+    action: 'issue.create',
+    payload: { owner: 'a', repo: 'b', title: 't', body: 'b' },
+    description: 'desc',
+    urgency: 0.3,
+    context: 'ctx',
+    draftedAt: '2026-04-26T00:00:00.000Z',
+  };
+
+  it('is deterministic across runs', () => {
+    expect(hashIntention(base)).toBe(hashIntention({ ...base }));
+  });
+
+  it('changes when payload changes', () => {
+    const other = { ...base, payload: { ...(base.payload as object), title: 't2' } };
+    expect(hashIntention(other)).not.toBe(hashIntention(base));
+  });
+
+  it('treats missing context as null, not absent', () => {
+    const a = hashIntention({ ...base, context: undefined });
+    const b = hashIntention({ ...base, context: undefined });
+    expect(a).toBe(b);
+  });
+});
+
+describe('signAttestation', () => {
+  it('produces a verifiable Ed25519 signature', () => {
+    const { privateKeyPem, publicKeyPem } = freshKeypair();
+    const intention: Intention<unknown> = {
+      id: 'i1',
+      connector: 'github',
+      action: 'issue.create',
+      payload: { owner: 'a', repo: 'b', title: 't', body: 'b' },
+      description: 'd',
+      urgency: 0.3,
+      draftedAt: '2026-04-26T00:00:00.000Z',
+    };
+    const att = signAttestation({
+      intention,
+      memberId: 'member-abc',
+      channel: 'voice',
+      privateKeyPem,
+      publicKeyPem,
+      timestamp: '2026-04-26T01:00:00.000Z',
+    });
+
+    // Re-construct the canonical bytes the signer committed to.
+    const canonical = JSON.stringify({
+      memberId: 'member-abc',
+      intentionHash: hashIntention(intention),
+      channel: 'voice',
+      timestamp: '2026-04-26T01:00:00.000Z',
+    });
+    // Ed25519 verification: crypto.verify with algorithm=null.
+    const publicKey = crypto.createPublicKey({ key: publicKeyPem, format: 'pem' });
+    const ok = crypto.verify(
+      null,
+      Buffer.from(canonical, 'utf8'),
+      publicKey,
+      Buffer.from(att.signature, 'base64'),
+    );
+    expect(ok).toBe(true);
+
+    // Public key round-trips.
+    const decodedPem = Buffer.from(att.publicKey, 'base64').toString('utf8');
+    expect(decodedPem).toBe(publicKeyPem);
+  });
+});
+
+describe('renderAttestationBlock', () => {
+  it('renders a collapsed details block with JSON inside', () => {
+    const att: PACTAttestation = {
+      memberId: 'm',
+      intentionHash: 'h',
+      channel: 'text',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      publicKey: 'pk',
+      signature: 'sig',
+    };
+    const out = renderAttestationBlock(att);
+    expect(out).toContain('<details>');
+    expect(out).toContain('<summary>HMAN PACT attestation</summary>');
+    expect(out).toContain('"memberId": "m"');
+    expect(out).toContain('"channel": "text"');
+  });
+});
+
+describe('parseDraftReply', () => {
+  it('parses well-formed JSON reply', () => {
+    const reply = '{"title":"Fix Muse handshake","body":"## Context\\n\\n> handshake fails"}';
+    const out = parseDraftReply(reply, 'whatever');
+    expect(out.title).toBe('Fix Muse handshake');
+    expect(out.body).toContain('handshake fails');
+  });
+
+  it('extracts JSON when LLM wraps it in prose', () => {
+    const reply = 'Sure, here is the draft:\n{"title":"X","body":"Y"}\nLet me know if you want changes.';
+    const out = parseDraftReply(reply, 'ctx');
+    expect(out.title).toBe('X');
+  });
+
+  it('falls back to a stub when the reply is unparseable', () => {
+    const out = parseDraftReply('garbage with no JSON at all', 'the muse handshake is annoying');
+    expect(out.title.length).toBeGreaterThan(0);
+    expect(out.body).toContain('the muse handshake is annoying');
+  });
+
+  it('truncates very long stub titles', () => {
+    const ctx = 'a'.repeat(200);
+    const out = parseDraftReply('not json', ctx);
+    expect(out.title.length).toBeLessThanOrEqual(70);
+  });
+});
+
+describe('GitHubConnector.draft', () => {
+  it('returns an Intention with the LLM draft', async () => {
+    const llm = new StubLLM('{"title":"Fix Muse handshake","body":"It fails."}');
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      llm,
+      github: new StubGitHub(),
+      now: () => new Date('2026-04-26T00:00:00.000Z'),
+    });
+    const intention = await c.draft({ context: 'this Muse handshake is annoying' });
+    expect(intention.connector).toBe('github');
+    expect(intention.action).toBe('issue.create');
+    expect(intention.payload.title).toBe('Fix Muse handshake');
+    expect(intention.payload.owner).toBe('example');
+    expect(intention.payload.repo).toBe('repo');
+    expect(intention.urgency).toBeGreaterThan(0);
+    expect(intention.urgency).toBeLessThanOrEqual(1);
+    expect(intention.draftedAt).toBe('2026-04-26T00:00:00.000Z');
+    expect(intention.id).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+});
+
+describe('GitHubConnector.execute', () => {
+  it('embeds the attestation block in the issue body and returns artifactUrl', async () => {
+    const { privateKeyPem, publicKeyPem } = freshKeypair();
+    const stub = new StubGitHub();
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      llm: new StubLLM('{"title":"X","body":"Y"}'),
+      github: stub,
+    });
+    const intention = await c.draft({ context: 'something broke' });
+    const att = signAttestation({
+      intention,
+      memberId: 'member-abc',
+      channel: 'voice',
+      privateKeyPem,
+      publicKeyPem,
+    });
+    const result = await c.execute(intention, att);
+    expect(result.success).toBe(true);
+    expect(result.artifactUrl).toBe('https://github.com/example/repo/issues/42');
+    expect(result.artifactId).toBe('example/repo#42');
+    expect(stub.lastCreate?.body).toContain('<details>');
+    expect(stub.lastCreate?.body).toContain('HMAN PACT attestation');
+    expect(stub.lastCreate?.body).toContain(att.signature);
+  });
+
+  it('refuses if the attestation hash does not match the intention', async () => {
+    const { privateKeyPem, publicKeyPem } = freshKeypair();
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      llm: new StubLLM('{"title":"A","body":"B"}'),
+      github: new StubGitHub(),
+    });
+    const intention = await c.draft({ context: 'ctx' });
+    const evilIntention = { ...intention, payload: { ...intention.payload, title: 'tampered' } };
+    const att = signAttestation({
+      intention,
+      memberId: 'm',
+      channel: 'voice',
+      privateKeyPem,
+      publicKeyPem,
+    });
+    const result = await c.execute(evilIntention, att);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/hash mismatch/);
+  });
+
+  it('refuses if owner/repo is not whitelisted', async () => {
+    const { privateKeyPem, publicKeyPem } = freshKeypair();
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      allowedRepos: [{ owner: 'allowed', repo: 'thing' }],
+      llm: new StubLLM('{"title":"A","body":"B"}'),
+      github: new StubGitHub(),
+    });
+    const intention = await c.draft({ context: 'ctx' });
+    const att = signAttestation({
+      intention,
+      memberId: 'm',
+      channel: 'voice',
+      privateKeyPem,
+      publicKeyPem,
+    });
+    const result = await c.execute(intention, att);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/whitelist/);
+  });
+
+  it('returns structured error on REST failure rather than throwing', async () => {
+    const { privateKeyPem, publicKeyPem } = freshKeypair();
+    const stub = new StubGitHub({ number: 1, html_url: 'x' }, new Error('rate-limited'));
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      llm: new StubLLM('{"title":"A","body":"B"}'),
+      github: stub,
+    });
+    const intention = await c.draft({ context: 'ctx' });
+    const att = signAttestation({
+      intention,
+      memberId: 'm',
+      channel: 'voice',
+      privateKeyPem,
+      publicKeyPem,
+    });
+    const result = await c.execute(intention, att);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/rate-limited/);
+  });
+});
+
+describe('GitHubConnector.undo', () => {
+  it('closes the issue with a rescinded comment', async () => {
+    const { privateKeyPem, publicKeyPem } = freshKeypair();
+    const stub = new StubGitHub();
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      llm: new StubLLM('{"title":"A","body":"B"}'),
+      github: stub,
+    });
+    const intention = await c.draft({ context: 'ctx' });
+    const att = signAttestation({
+      intention,
+      memberId: 'm',
+      channel: 'voice',
+      privateKeyPem,
+      publicKeyPem,
+    });
+    const result = await c.execute(intention, att);
+    await c.undo!(result);
+    expect(stub.lastClose).toBeDefined();
+    expect(stub.lastClose?.owner).toBe('example');
+    expect(stub.lastClose?.repo).toBe('repo');
+    expect(stub.lastClose?.issue_number).toBe(42);
+    expect(stub.lastClose?.comment).toMatch(/rescinded/);
+  });
+
+  it('is a no-op on an unsuccessful result', async () => {
+    const stub = new StubGitHub();
+    const c = new GitHubConnector({
+      defaultOwner: 'example',
+      defaultRepo: 'repo',
+      llm: new StubLLM('{"title":"A","body":"B"}'),
+      github: stub,
+    });
+    await c.undo!({
+      success: false,
+      attestation: {
+        memberId: 'm',
+        intentionHash: 'h',
+        channel: 'voice',
+        timestamp: 't',
+        publicKey: 'pk',
+        signature: 'sig',
+      },
+    });
+    expect(stub.lastClose).toBeUndefined();
+  });
+});

--- a/packages/core/src/connectors/Connector.ts
+++ b/packages/core/src/connectors/Connector.ts
@@ -1,0 +1,162 @@
+/**
+ * HMAN Connector — base interface for every external action HMAN takes
+ * on a member's behalf.
+ *
+ * The contract is the load-bearing piece: every future connector (Bank,
+ * Tailor, Calendar, email, Slack, …) implements this same shape so the
+ * receptivity gate, consent UI, audit log, and undo path can treat them
+ * uniformly.
+ *
+ * Lifecycle of a single external action:
+ *
+ *   1. ``draft({ context })`` — the subconscious has noticed a moment
+ *      where an external action might be useful. The connector turns
+ *      free-form context (e.g. a transcript snippet) into a structured
+ *      ``Intention`` with a typed payload.
+ *
+ *   2. The bridge stores the Intention in the vault keyed by ``id`` and
+ *      hands it to the receptivity gate. The gate decides *when* and
+ *      *how* to surface the consent moment (voice / text / queue).
+ *
+ *   3. The member consents through the chosen channel. The bridge signs
+ *      a ``PACTAttestation`` over the intention hash + member ID + the
+ *      channel that was actually used + the timestamp.
+ *
+ *   4. ``execute(intention, attestation)`` — the connector performs the
+ *      external action, embedding the attestation alongside it so the
+ *      artifact (the GitHub issue, the bank transfer reference, …) is
+ *      verifiably an authorized member action.
+ *
+ *   5. ``undo?(result)`` — optional. Issues yes (low blast radius),
+ *      payments no. Each connector decides.
+ */
+
+/**
+ * PACT attestation — the proof a connector embeds alongside the
+ * external action to make it verifiable.
+ *
+ * This shape is intentionally a plain JSON-serialisable object so it
+ * can be embedded inside an issue body, a bank-transfer reference, an
+ * email header, etc. without any platform-specific binary plumbing.
+ *
+ * NOTE: this is the *envelope*. The PACT spec lives in the separate
+ * ``protocol/pact/`` repo — when that pins the canonical wire format
+ * we'll narrow this type. For now we mirror the fields every consumer
+ * needs to verify the action.
+ */
+export interface PACTAttestation {
+  /** Stable member identifier (anonymised hash, never PII). */
+  memberId: string;
+  /** Hash of the canonical Intention bytes the member consented to. */
+  intentionHash: string;
+  /** Channel through which consent was actually obtained. */
+  channel: 'voice' | 'text' | 'queue';
+  /** ISO-8601 timestamp the member said yes. */
+  timestamp: string;
+  /** Ed25519 public key of the signer (base64). */
+  publicKey: string;
+  /** Ed25519 signature over a canonical serialisation of the fields above (base64). */
+  signature: string;
+}
+
+/**
+ * Intention — what HMAN is *thinking about* doing, before consent.
+ *
+ * ``TPayload`` is the connector-specific shape the action needs. For
+ * GitHub it's ``{ owner, repo, title, body }``; for a bank transfer it
+ * would be ``{ payeePayId, amount, currency, reference }``.
+ */
+export interface Intention<TPayload = unknown> {
+  /** Stable id (uuid) — the same value gates, consent UI and audit all use. */
+  id: string;
+  /** Connector name, e.g. ``"github"``, ``"bank"``. */
+  connector: string;
+  /** Action verb the connector understands, e.g. ``"issue.create"``. */
+  action: string;
+  /** Connector-specific payload. */
+  payload: TPayload;
+  /** Member-facing one-line description for the consent surface. */
+  description: string;
+  /** Urgency in [0, 1] — fed to the receptivity gate. */
+  urgency: number;
+  /**
+   * Free-form context (transcript snippet, screenshot OCR, …) that
+   * informed the draft. Kept so the consent prompt can quote the
+   * member's own words back to them.
+   */
+  context?: string;
+  /** ISO-8601 timestamp the draft was produced. */
+  draftedAt: string;
+}
+
+/** What a connector returns after attempting to execute. */
+export interface ExecutionResult {
+  /** True if the external service confirmed the action. */
+  success: boolean;
+  /** Human-visible URL of the resulting artifact, when there is one. */
+  artifactUrl?: string;
+  /** A stable id the connector can use to ``undo`` later (e.g. issue number). */
+  artifactId?: string;
+  /** The attestation that was embedded — caller persists this in the audit. */
+  attestation: PACTAttestation;
+  /** Populated only when ``success`` is false. */
+  error?: string;
+}
+
+/**
+ * Receptivity-gate interface every connector imports.
+ *
+ * The canonical implementation lives in the Python bridge at
+ * ``packages/python-bridge/receptivity/`` (PR #5). This thin TypeScript
+ * shadow lets the TS connector code remain decoupled — any caller can
+ * inject either the live REST-backed gate or a stub for tests. When
+ * #4 lands and we settle on a canonical TS port we'll re-export from
+ * that module instead.
+ */
+export interface ReceptivityGate {
+  /**
+   * Ask the gate whether to surface the intention right now and on which
+   * channel.  The gate is the only thing that decides — the connector
+   * never surfaces itself.
+   */
+  evaluate(intention: Intention): Promise<GateDecision>;
+}
+
+/** Mirror of the Python ``GateDecision`` returned by ``/api/receptivity/evaluate``. */
+export interface GateDecision {
+  surfaceNow: boolean;
+  channel: 'voice' | 'text' | 'queue';
+  reason: string;
+  score: number;
+  budgetWordsRemaining: number;
+  budgetInterruptionsToday: number;
+}
+
+/**
+ * Connector — every external action HMAN takes implements this.
+ */
+export interface Connector<TPayload = unknown> {
+  /** Stable connector id, e.g. ``"github"``. */
+  readonly name: string;
+
+  /**
+   * Turn free-form context into a typed Intention. The connector is
+   * responsible for filling out a useful ``description`` — that's the
+   * line the member will hear or read at the consent moment.
+   */
+  draft(input: { context: string; memberId?: string }): Promise<Intention<TPayload>>;
+
+  /**
+   * Perform the external action and embed the attestation alongside.
+   * Returns success metadata or a structured error — never throws on
+   * expected failure paths (network, auth, rate-limit).
+   */
+  execute(intention: Intention<TPayload>, attestation: PACTAttestation): Promise<ExecutionResult>;
+
+  /**
+   * Optional — reverse a previous execution. Connectors with low blast
+   * radius (issues, calendar invites, draft emails) implement this;
+   * irreversible ones (payments) do not.
+   */
+  undo?(result: ExecutionResult): Promise<void>;
+}

--- a/packages/core/src/connectors/github.ts
+++ b/packages/core/src/connectors/github.ts
@@ -1,0 +1,286 @@
+/**
+ * GitHubConnector — first concrete implementation of the Connector contract.
+ *
+ * Flow:
+ *   1. ``draft({ context })`` — call the LLM to turn a transcript snippet
+ *      into ``{ title, body }``, packaged as an Intention.
+ *   2. ``execute(intention, attestation)`` — embed the attestation in a
+ *      collapsed ``<details>`` block at the bottom of the issue body and
+ *      POST to the GitHub REST API.
+ *   3. ``undo(result)`` — close the issue with a "rescinded by member"
+ *      comment.  Issues are low blast radius so undo is safe.
+ */
+
+import * as crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  Connector,
+  ExecutionResult,
+  Intention,
+  PACTAttestation,
+} from './Connector.js';
+import {
+  FetchGitHubClient,
+  OllamaLLMClient,
+  type GitHubClient,
+  type LLMClient,
+} from './types.js';
+
+/** Payload shape the GitHub connector hands GitHub's REST API. */
+export interface GitHubIssuePayload {
+  owner: string;
+  repo: string;
+  title: string;
+  body: string;
+}
+
+export interface GitHubConnectorConfig {
+  /** Default repo to file against when the LLM doesn't pick one. */
+  defaultOwner: string;
+  defaultRepo: string;
+  /** Optional whitelist — execute throws if owner/repo isn't in this list. */
+  allowedRepos?: ReadonlyArray<{ owner: string; repo: string }>;
+  /** Injected for testing; defaults to Ollama on localhost:11434. */
+  llm?: LLMClient;
+  /** Injected for testing; defaults to fetch against api.github.com. */
+  github?: GitHubClient;
+  /** Override clock for tests. */
+  now?: () => Date;
+}
+
+/**
+ * Compute the canonical hash a PACT signature should cover for an
+ * Intention. Must be deterministic — every party that re-derives the
+ * hash from the same Intention object gets the same value.
+ */
+export function hashIntention(intention: Intention<unknown>): string {
+  // Stable key order so JSON.stringify is deterministic across runs.
+  const stable = {
+    id: intention.id,
+    connector: intention.connector,
+    action: intention.action,
+    payload: intention.payload,
+    description: intention.description,
+    urgency: intention.urgency,
+    context: intention.context ?? null,
+    draftedAt: intention.draftedAt,
+  };
+  return crypto.createHash('sha256').update(JSON.stringify(stable)).digest('hex');
+}
+
+/** Render a PACT attestation as a collapsed Markdown block. */
+export function renderAttestationBlock(attestation: PACTAttestation): string {
+  // Pretty JSON inside the fence so a human reader can eyeball the fields.
+  const json = JSON.stringify(attestation, null, 2);
+  return [
+    '',
+    '<!-- HMAN PACT attestation — verifies this issue was an authorized member action. -->',
+    '<details>',
+    '<summary>HMAN PACT attestation</summary>',
+    '',
+    '```json',
+    json,
+    '```',
+    '',
+    '_Verify this signature with the public key above against the canonical hash of the issue payload._',
+    '</details>',
+  ].join('\n');
+}
+
+/**
+ * Sign an Intention as a PACT attestation. The signing keypair lives
+ * outside this module — pass either a base64 Ed25519 secret key plus
+ * its public key, or a complete pre-built ``PACTAttestation`` shape.
+ *
+ * This helper exists so the bridge can call ``execute`` with the same
+ * canonical attestation shape every connector embeds.
+ */
+export function signAttestation(input: {
+  intention: Intention<unknown>;
+  memberId: string;
+  channel: 'voice' | 'text' | 'queue';
+  privateKeyPem: string;
+  publicKeyPem: string;
+  timestamp?: string;
+}): PACTAttestation {
+  const intentionHash = hashIntention(input.intention);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  // Canonical bytes the signature commits to.
+  const canonical = JSON.stringify({
+    memberId: input.memberId,
+    intentionHash,
+    channel: input.channel,
+    timestamp,
+  });
+  // Ed25519 in node 17+ uses the one-shot crypto.sign with algorithm=null
+  // (Ed25519 takes the message directly, not a digest).
+  const privateKey = crypto.createPrivateKey({ key: input.privateKeyPem, format: 'pem' });
+  const signature = crypto.sign(null, Buffer.from(canonical, 'utf8'), privateKey).toString('base64');
+  // Encode the public key as base64 of the raw PEM contents so it
+  // round-trips cleanly inside JSON. Verifiers re-import with
+  // ``crypto.createPublicKey({ key: pem, format: 'pem' })``.
+  const publicKey = Buffer.from(input.publicKeyPem, 'utf8').toString('base64');
+  return {
+    memberId: input.memberId,
+    intentionHash,
+    channel: input.channel,
+    timestamp,
+    publicKey,
+    signature,
+  };
+}
+
+const DRAFT_SYSTEM_PROMPT = `You are HMAN's drafting subconscious. The member casually mentioned a bug or feature request in conversation. Turn what they said into a concise, actionable GitHub issue.
+
+Output ONLY a JSON object on a single line with two keys: "title" and "body".
+
+Rules:
+- "title" is under 70 chars, imperative mood, no trailing period.
+- "body" is plain Markdown. Open with one sentence stating the problem or request from the member's point of view, then a short "## Context" section quoting their actual words verbatim.
+- Don't fabricate symptoms, error messages, or stack traces the member didn't say.
+- Don't add labels, milestones, or assignees — the LLM does NOT auto-categorize.
+- Don't include any HMAN attestation block — that's appended separately.`;
+
+export class GitHubConnector implements Connector<GitHubIssuePayload> {
+  readonly name = 'github';
+
+  private readonly defaultOwner: string;
+  private readonly defaultRepo: string;
+  private readonly allowedRepos?: ReadonlyArray<{ owner: string; repo: string }>;
+  private readonly llm: LLMClient;
+  private readonly github: GitHubClient;
+  private readonly now: () => Date;
+
+  constructor(config: GitHubConnectorConfig) {
+    this.defaultOwner = config.defaultOwner;
+    this.defaultRepo = config.defaultRepo;
+    this.allowedRepos = config.allowedRepos;
+    this.llm = config.llm ?? new OllamaLLMClient();
+    this.github = config.github ?? new FetchGitHubClient();
+    this.now = config.now ?? (() => new Date());
+  }
+
+  async draft(input: { context: string; memberId?: string }): Promise<Intention<GitHubIssuePayload>> {
+    const reply = await this.llm.chat({
+      system: DRAFT_SYSTEM_PROMPT,
+      user: input.context,
+      options: { temperature: 0.2 },
+    });
+    const { title, body } = parseDraftReply(reply, input.context);
+    const intention: Intention<GitHubIssuePayload> = {
+      id: uuidv4(),
+      connector: this.name,
+      action: 'issue.create',
+      payload: {
+        owner: this.defaultOwner,
+        repo: this.defaultRepo,
+        title,
+        body,
+      },
+      description: `File a GitHub issue: "${title}"`,
+      // Bug reports in casual conversation are almost never urgent —
+      // start low and let the member upgrade later.
+      urgency: 0.3,
+      context: input.context,
+      draftedAt: this.now().toISOString(),
+    };
+    return intention;
+  }
+
+  async execute(
+    intention: Intention<GitHubIssuePayload>,
+    attestation: PACTAttestation,
+  ): Promise<ExecutionResult> {
+    // Cross-check: the attestation must commit to *this* intention.
+    const expected = hashIntention(intention);
+    if (attestation.intentionHash !== expected) {
+      return {
+        success: false,
+        attestation,
+        error: `attestation/intention hash mismatch (expected ${expected}, got ${attestation.intentionHash})`,
+      };
+    }
+
+    const { owner, repo, title, body } = intention.payload;
+
+    if (this.allowedRepos && !this.allowedRepos.some((r) => r.owner === owner && r.repo === repo)) {
+      return {
+        success: false,
+        attestation,
+        error: `repo ${owner}/${repo} not in allowedRepos whitelist`,
+      };
+    }
+
+    const composedBody = `${body.trim()}\n\n${renderAttestationBlock(attestation)}\n`;
+
+    try {
+      const issue = await this.github.createIssue({ owner, repo, title, body: composedBody });
+      return {
+        success: true,
+        artifactUrl: issue.html_url,
+        artifactId: `${owner}/${repo}#${issue.number}`,
+        attestation,
+      };
+    } catch (e) {
+      return {
+        success: false,
+        attestation,
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+
+  async undo(result: ExecutionResult): Promise<void> {
+    if (!result.success || !result.artifactId) return;
+    // artifactId format: "owner/repo#number"
+    const match = /^([^/]+)\/([^#]+)#(\d+)$/.exec(result.artifactId);
+    if (!match) {
+      throw new Error(`cannot parse artifactId for undo: ${result.artifactId}`);
+    }
+    const [, owner, repo, num] = match;
+    await this.github.closeIssue({
+      owner,
+      repo,
+      issue_number: Number(num),
+      comment:
+        'Closed by HMAN: member rescinded consent for this action. ' +
+        'Original PACT attestation in the issue body remains valid history.',
+    });
+  }
+}
+
+/**
+ * Parse the LLM's reply into ``{ title, body }``. The LLM is asked for
+ * a single-line JSON object but real models leak prose around it; this
+ * extracts the first JSON object and falls back to a stub-issue using
+ * the raw context if parsing fails.
+ */
+export function parseDraftReply(
+  reply: string,
+  context: string,
+): { title: string; body: string } {
+  // Find the first { ... } JSON-shaped substring.
+  const start = reply.indexOf('{');
+  const end = reply.lastIndexOf('}');
+  if (start !== -1 && end !== -1 && end > start) {
+    const slice = reply.slice(start, end + 1);
+    try {
+      const parsed = JSON.parse(slice) as { title?: unknown; body?: unknown };
+      const title = typeof parsed.title === 'string' && parsed.title.trim().length > 0
+        ? parsed.title.trim().slice(0, 120)
+        : null;
+      const body = typeof parsed.body === 'string' && parsed.body.trim().length > 0
+        ? parsed.body.trim()
+        : null;
+      if (title && body) return { title, body };
+    } catch {
+      // fall through to stub
+    }
+  }
+  // Stub fallback — better to file *something* than to silently drop
+  // the member's context. Title is a truncation, body quotes them.
+  const trimmed = context.trim().replace(/\s+/g, ' ');
+  const title = trimmed.length > 70 ? trimmed.slice(0, 67) + '...' : trimmed || 'Untitled issue from voice draft';
+  const body = `## Context\n\n> ${trimmed || '(no context captured)'}\n\n_Drafted by HMAN — the LLM did not return a structured response, so this is a verbatim quote of the member's words._`;
+  return { title, body };
+}

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @hman/core/connectors — external action surface.
+ *
+ * Public API:
+ *   - ``Connector`` — the base interface every external action implements.
+ *   - ``Intention``, ``ExecutionResult``, ``PACTAttestation`` — wire shapes.
+ *   - ``ReceptivityGate`` — thin TS shadow of the bridge's gate interface.
+ *   - ``GitHubConnector`` — first concrete impl.
+ *   - helpers: ``hashIntention``, ``signAttestation``, ``renderAttestationBlock``.
+ */
+
+export type {
+  Connector,
+  Intention,
+  ExecutionResult,
+  PACTAttestation,
+  ReceptivityGate,
+  GateDecision,
+} from './Connector.js';
+
+export {
+  GitHubConnector,
+  hashIntention,
+  renderAttestationBlock,
+  signAttestation,
+  parseDraftReply,
+  type GitHubIssuePayload,
+  type GitHubConnectorConfig,
+} from './github.js';
+
+export {
+  OllamaLLMClient,
+  FetchGitHubClient,
+  type LLMClient,
+  type GitHubClient,
+} from './types.js';

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,0 +1,175 @@
+/**
+ * Connector helper types — small interfaces the impls inject so they
+ * stay testable without external services.
+ */
+
+/**
+ * Tiny LLM client interface. The default impl posts to a local Ollama
+ * server, but tests inject stubs that return canned drafts. Keeping
+ * this internal to the connectors module means we can swap the
+ * platform-wide LLM abstraction in later without touching connector code.
+ */
+export interface LLMClient {
+  /** Send a chat-style prompt and return the assistant text. */
+  chat(input: {
+    system: string;
+    user: string;
+    /** Free-form options passed straight to the underlying server. */
+    options?: Record<string, unknown>;
+  }): Promise<string>;
+}
+
+/**
+ * Default Ollama-backed LLM client. Hits ``http://localhost:11434/api/chat``
+ * with the model name caller specifies.  No retries, no streaming — the
+ * connector's ``draft`` step is single-shot and small.
+ */
+export class OllamaLLMClient implements LLMClient {
+  constructor(
+    private readonly model: string = 'llama3.2:3b',
+    private readonly endpoint: string = 'http://localhost:11434/api/chat',
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async chat(input: {
+    system: string;
+    user: string;
+    options?: Record<string, unknown>;
+  }): Promise<string> {
+    const res = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          { role: 'system', content: input.system },
+          { role: 'user', content: input.user },
+        ],
+        stream: false,
+        options: input.options,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Ollama chat failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as { message?: { content?: string } };
+    return data.message?.content?.trim() ?? '';
+  }
+}
+
+/**
+ * Tiny GitHub REST client interface. Tests inject a stub; the default
+ * impl uses ``fetch`` against ``api.github.com``.
+ *
+ * Scope: only the verbs the connector actually needs. Adding more is
+ * fine, but every method here must remain side-effect-light enough that
+ * the receptivity gate's ``undo`` semantics still hold.
+ */
+export interface GitHubClient {
+  createIssue(input: {
+    owner: string;
+    repo: string;
+    title: string;
+    body: string;
+  }): Promise<{ number: number; html_url: string }>;
+
+  /** Close an issue, posting an explanatory comment. Used by ``undo``. */
+  closeIssue(input: {
+    owner: string;
+    repo: string;
+    issue_number: number;
+    comment?: string;
+  }): Promise<void>;
+}
+
+/**
+ * Default GitHub REST client. Reads the token from the environment by
+ * default so tokens don't leak through ctor args. Pass an explicit
+ * ``token`` for programmatic use; pass a custom ``fetchImpl`` for tests.
+ */
+export class FetchGitHubClient implements GitHubClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: {
+    token?: string;
+    baseUrl?: string;
+    fetchImpl?: typeof fetch;
+  } = {}) {
+    this.baseUrl = opts.baseUrl ?? 'https://api.github.com';
+    // Read token lazily from env so tests can construct without setting it
+    this.token = opts.token ?? process.env.HMAN_GITHUB_TOKEN ?? '';
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private headers(): Record<string, string> {
+    if (!this.token) {
+      throw new Error(
+        'HMAN_GITHUB_TOKEN not set — cannot call GitHub. Use a fine-grained PAT with issues:write on the whitelisted repo.',
+      );
+    }
+    return {
+      Authorization: `Bearer ${this.token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async createIssue(input: {
+    owner: string;
+    repo: string;
+    title: string;
+    body: string;
+  }): Promise<{ number: number; html_url: string }> {
+    const res = await this.fetchImpl(
+      `${this.baseUrl}/repos/${encodeURIComponent(input.owner)}/${encodeURIComponent(input.repo)}/issues`,
+      {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify({ title: input.title, body: input.body }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitHub issue create failed: ${res.status} ${text.slice(0, 200)}`);
+    }
+    const data = (await res.json()) as { number: number; html_url: string };
+    return { number: data.number, html_url: data.html_url };
+  }
+
+  async closeIssue(input: {
+    owner: string;
+    repo: string;
+    issue_number: number;
+    comment?: string;
+  }): Promise<void> {
+    if (input.comment) {
+      const commentRes = await this.fetchImpl(
+        `${this.baseUrl}/repos/${encodeURIComponent(input.owner)}/${encodeURIComponent(input.repo)}/issues/${input.issue_number}/comments`,
+        {
+          method: 'POST',
+          headers: this.headers(),
+          body: JSON.stringify({ body: input.comment }),
+        },
+      );
+      if (!commentRes.ok) {
+        const text = await commentRes.text();
+        throw new Error(`GitHub issue comment failed: ${commentRes.status} ${text.slice(0, 200)}`);
+      }
+    }
+    const res = await this.fetchImpl(
+      `${this.baseUrl}/repos/${encodeURIComponent(input.owner)}/${encodeURIComponent(input.repo)}/issues/${input.issue_number}`,
+      {
+        method: 'PATCH',
+        headers: this.headers(),
+        body: JSON.stringify({ state: 'closed', state_reason: 'not_planned' }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitHub issue close failed: ${res.status} ${text.slice(0, 200)}`);
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -225,3 +225,27 @@ export {
   type DataRequest,
   type DataResponse,
 } from './bridge.js';
+
+// Connectors module - external actions HMAN takes on a member's behalf
+// Note: ``ExecutionResult`` and ``GateDecision`` are also exported from
+// services/access; we re-export the connector-flavoured ones under
+// distinct aliases so callers can reach for either without ambiguity.
+export {
+  GitHubConnector,
+  hashIntention,
+  renderAttestationBlock,
+  signAttestation,
+  parseDraftReply,
+  OllamaLLMClient,
+  FetchGitHubClient,
+  type Connector,
+  type Intention,
+  type ExecutionResult as ConnectorExecutionResult,
+  type PACTAttestation,
+  type ReceptivityGate,
+  type GateDecision as ReceptivityGateDecision,
+  type GitHubIssuePayload,
+  type GitHubConnectorConfig,
+  type LLMClient,
+  type GitHubClient,
+} from './connectors/index.js';

--- a/packages/python-bridge/api/connectors.py
+++ b/packages/python-bridge/api/connectors.py
@@ -1,0 +1,217 @@
+"""HTTP endpoints for the connector subsystem.
+
+Surface:
+  - ``POST /api/connectors/github/draft``
+        body: ``{"context": "..."}``
+        returns: an Intention (camelCase JSON) — also persisted to disk
+        keyed by ``id``.
+
+  - ``POST /api/connectors/github/execute``
+        body: ``{"intentionId": "...", "channel": "voice"|"text"}``
+        Re-verifies Gate 5, signs a PACT attestation, calls the
+        connector's ``execute``, appends to the audit log, and removes
+        the intention from the on-disk store.
+
+  - ``GET /api/connectors/github/intentions``
+        Lists drafted-but-not-yet-executed intentions (for the dashboard
+        queue page).
+
+  - ``DELETE /api/connectors/github/intentions/{id}``
+        Drop a draft without executing it. Logged as ``decided`` with
+        ``decision="drop"``.
+
+Both the draft and execute endpoints depend on Gate 5 being armed —
+the same biometric check ``/api/gate5/verify`` enforces. The execute
+endpoint does *not* take fresh audio (the consent moment is short and
+audio capture happens client-side); instead the caller must have
+verified Gate 5 within the last ``GATE5_FRESHNESS_SECONDS`` seconds.
+The bridge tracks the most recent activation in its in-memory state
+and rejects requests when the last accept is too old.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from connectors import (
+    GitHubConnector,
+    append_event,
+    sign_attestation,
+)
+from connectors import store as intention_store
+
+
+router = APIRouter(prefix="/api/connectors/github", tags=["connectors"])
+
+
+# ── Pydantic wire shapes ────────────────────────────────────────────
+
+
+class DraftIn(BaseModel):
+    context: str
+    member_id: Optional[str] = None
+
+
+class IntentionOut(BaseModel):
+    id: str
+    connector: str
+    action: str
+    payload: dict
+    description: str
+    urgency: float
+    context: Optional[str] = None
+    draftedAt: str
+
+
+class ExecuteIn(BaseModel):
+    intentionId: str
+    channel: str  # "voice" | "text"
+    member_id: str = "member"
+
+
+class ExecutionResultOut(BaseModel):
+    success: bool
+    artifactUrl: Optional[str] = None
+    artifactId: Optional[str] = None
+    attestation: dict
+    error: Optional[str] = None
+
+
+class IntentionListOut(BaseModel):
+    intentions: list[IntentionOut]
+
+
+# ── Shared connector instance ───────────────────────────────────────
+#
+# Lazily constructed so import-time env reads don't fail in tests.
+
+_connector: Optional[GitHubConnector] = None
+
+
+def get_connector() -> GitHubConnector:
+    global _connector
+    if _connector is None:
+        _connector = GitHubConnector()
+    return _connector
+
+
+# ── Gate 5 freshness check ──────────────────────────────────────────
+#
+# The consent moment must be backed by a *recent* Gate-5 verify event.
+# The dependency is wired by ``server.py`` at mount time so this module
+# can be imported without server-state coupling.
+
+GATE5_FRESHNESS_SECONDS = 60
+
+_gate5_check: Optional[Callable[[], tuple[bool, str]]] = None
+
+
+def configure_gate5_check(check: Callable[[], tuple[bool, str]]) -> None:
+    """Register the Gate-5 freshness check. Returns ``(ok, reason)``.
+
+    ``ok`` is True iff Gate 5 is armed AND ``last_activation`` is within
+    GATE5_FRESHNESS_SECONDS. The reason string surfaces in the 401 body.
+    """
+    global _gate5_check
+    _gate5_check = check
+
+
+def _require_fresh_gate5() -> None:
+    if _gate5_check is None:
+        # Bridge wasn't wired — fail closed.
+        raise HTTPException(status_code=503, detail="Gate 5 freshness check not configured")
+    ok, reason = _gate5_check()
+    if not ok:
+        raise HTTPException(status_code=401, detail=f"Gate 5 not fresh: {reason}")
+
+
+# ── Endpoints ───────────────────────────────────────────────────────
+
+
+@router.post("/draft", response_model=IntentionOut)
+def draft(body: DraftIn) -> IntentionOut:
+    _require_fresh_gate5()
+    connector = get_connector()
+    intention = connector.draft(context=body.context, member_id=body.member_id)
+    intention_store.save(intention)
+    append_event(
+        "drafted",
+        intention_id=intention.id,
+        connector=intention.connector,
+        member_id=body.member_id,
+        extra={"description": intention.description, "urgency": intention.urgency},
+    )
+    d = intention.to_dict()
+    return IntentionOut(**d)
+
+
+@router.post("/execute", response_model=ExecutionResultOut)
+def execute(body: ExecuteIn) -> ExecutionResultOut:
+    _require_fresh_gate5()
+    if body.channel not in ("voice", "text"):
+        raise HTTPException(status_code=400, detail=f"invalid channel: {body.channel}")
+
+    intention = intention_store.load(body.intentionId)
+    if intention is None:
+        raise HTTPException(status_code=404, detail=f"intention {body.intentionId} not found")
+
+    attestation = sign_attestation(
+        intention=intention,
+        member_id=body.member_id,
+        channel=body.channel,
+    )
+    append_event(
+        "decided",
+        intention_id=intention.id,
+        connector=intention.connector,
+        channel=body.channel,
+        member_id=body.member_id,
+        extra={"decision": "execute"},
+    )
+    connector = get_connector()
+    result = connector.execute(intention, attestation)
+    append_event(
+        "executed" if result.success else "failed",
+        intention_id=intention.id,
+        connector=intention.connector,
+        channel=body.channel,
+        artifact_url=result.artifact_url,
+        member_id=body.member_id,
+        extra={"error": result.error} if result.error else None,
+    )
+    if result.success:
+        intention_store.delete(intention.id)
+    return ExecutionResultOut(**result.to_dict())
+
+
+@router.get("/intentions", response_model=IntentionListOut)
+def list_intentions() -> IntentionListOut:
+    _require_fresh_gate5()
+    out: list[IntentionOut] = []
+    # ``store`` doesn't yet expose a list helper; iterate the directory.
+    from connectors.store import _STORE_DIR  # type: ignore[attr-defined]
+
+    if _STORE_DIR.exists():
+        for path in sorted(_STORE_DIR.glob("*.json")):
+            intention = intention_store.load(path.stem)
+            if intention is not None:
+                out.append(IntentionOut(**intention.to_dict()))
+    return IntentionListOut(intentions=out)
+
+
+@router.delete("/intentions/{intention_id}")
+def drop_intention(intention_id: str) -> dict:
+    _require_fresh_gate5()
+    intention = intention_store.load(intention_id)
+    if intention is None:
+        raise HTTPException(status_code=404, detail="not found")
+    intention_store.delete(intention_id)
+    append_event(
+        "decided",
+        intention_id=intention_id,
+        connector=intention.connector,
+        extra={"decision": "drop"},
+    )
+    return {"dropped": intention_id}

--- a/packages/python-bridge/api/server.py
+++ b/packages/python-bridge/api/server.py
@@ -1218,6 +1218,50 @@ async def pair_redeem(body: PairRedeemRequest, request: Request):
     return PairRedeemResponse(token=token)
 
 
+# ── Connectors (PACT-mediated external actions) ─────────────────────
+#
+# First implementation: PACT-GitHub. The connector's draft/execute path
+# is gated by Gate 5 freshness — the consent moment must be backed by
+# a recent voice-biometric activation. We register a freshness check
+# that the connectors module calls on every draft/execute request.
+
+from api import connectors as _connectors_router  # noqa: E402
+
+
+def _gate5_freshness_check() -> tuple[bool, str]:
+    """Return ``(ok, reason)`` for the connector module.
+
+    ``ok`` is True iff Gate 5 is armed AND the last accepting activation
+    is within ``GATE5_FRESHNESS_SECONDS`` of *now*. This is the
+    "is this still really the member" check the connector spec calls
+    for at the consent moment.
+    """
+    with _gate5_lock:
+        armed = _gate5_reference is not None
+        last = _gate5_last_activation
+    if not armed:
+        return False, "Gate 5 not armed (call /api/gate5/unlock first)"
+    if last is None:
+        return False, "Gate 5 has no recent successful activation"
+    try:
+        last_dt = datetime.fromisoformat(last)
+        now = datetime.now(last_dt.tzinfo) if last_dt.tzinfo else datetime.now()
+        delta = (now - last_dt).total_seconds()
+    except Exception:
+        return False, "Gate 5 last activation timestamp unparseable"
+    if delta > _connectors_router.GATE5_FRESHNESS_SECONDS:
+        return (
+            False,
+            f"Gate 5 last activation {int(delta)}s ago, "
+            f"freshness window {_connectors_router.GATE5_FRESHNESS_SECONDS}s",
+        )
+    return True, "fresh"
+
+
+_connectors_router.configure_gate5_check(_gate5_freshness_check)
+app.include_router(_connectors_router.router)
+
+
 # ── Dev entrypoint ──────────────────────────────────────────────────
 
 if __name__ == "__main__":

--- a/packages/python-bridge/connectors/__init__.py
+++ b/packages/python-bridge/connectors/__init__.py
@@ -1,0 +1,30 @@
+"""connectors — external actions HMAN takes on a member's behalf.
+
+The Connector contract is mirrored from ``packages/core/src/connectors/``
+so the Python bridge can ``draft`` and ``execute`` without needing a Node
+sidecar. The TypeScript module remains the canonical reference for
+browser/Node consumers; this Python module owns the bridge-side path.
+
+Public surface::
+
+    from connectors import GitHubConnector, sign_attestation, hash_intention
+    from connectors.types import Intention, PACTAttestation, ExecutionResult
+    from connectors.audit import append_event
+"""
+from __future__ import annotations
+
+from .github import GitHubConnector
+from .pact import sign_attestation, hash_intention, render_attestation_block
+from .types import Intention, PACTAttestation, ExecutionResult
+from .audit import append_event
+
+__all__ = [
+    "GitHubConnector",
+    "Intention",
+    "PACTAttestation",
+    "ExecutionResult",
+    "sign_attestation",
+    "hash_intention",
+    "render_attestation_block",
+    "append_event",
+]

--- a/packages/python-bridge/connectors/audit.py
+++ b/packages/python-bridge/connectors/audit.py
@@ -1,0 +1,55 @@
+"""Append-only audit log for connector lifecycle events.
+
+Every step (drafted, surfaced, decided, executed, undone) writes a line
+to ``~/.hman/logs/connector_events.jsonl``. The bridge never reads this
+file — it's a forensics record consumed offline by ``hman audit`` /
+``ops/audit-tail.ps1``.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+_DATA_ENV = os.environ.get("HMAN_DATA_DIR")
+_HMAN_DIR = Path(_DATA_ENV).expanduser().resolve() if _DATA_ENV else Path.home() / ".hman"
+_LOGS_DIR = _HMAN_DIR / "logs"
+_AUDIT_FILE = _LOGS_DIR / "connector_events.jsonl"
+
+
+def append_event(
+    event: str,
+    *,
+    intention_id: Optional[str] = None,
+    connector: Optional[str] = None,
+    channel: Optional[str] = None,
+    artifact_url: Optional[str] = None,
+    member_id: Optional[str] = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> None:
+    """Append a single audit line. Never raises — best-effort only."""
+    try:
+        _LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+        }
+        if intention_id is not None:
+            record["intention_id"] = intention_id
+        if connector is not None:
+            record["connector"] = connector
+        if channel is not None:
+            record["channel"] = channel
+        if artifact_url is not None:
+            record["artifact_url"] = artifact_url
+        if member_id is not None:
+            record["member_id"] = member_id
+        if extra:
+            record["extra"] = extra
+        with open(_AUDIT_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception:
+        # Audit must never block the connector. Swallow.
+        pass

--- a/packages/python-bridge/connectors/github.py
+++ b/packages/python-bridge/connectors/github.py
@@ -1,0 +1,289 @@
+"""GitHubConnector — Python mirror of ``packages/core/src/connectors/github.ts``.
+
+The bridge process owns the ``draft`` / ``execute`` path here so it can
+run without a Node sidecar. The TypeScript module is the canonical
+reference for browser/Node consumers; both must agree on the wire shape
+or attestations won't verify across languages.
+
+Configuration via environment:
+  - ``HMAN_GITHUB_TOKEN``       fine-grained PAT with ``issues:write``
+  - ``HMAN_GITHUB_DEFAULT_OWNER`` repo owner the LLM defaults to
+  - ``HMAN_GITHUB_DEFAULT_REPO``  repo name the LLM defaults to
+  - ``HMAN_GITHUB_ALLOWED_REPOS``  comma-separated ``owner/repo`` whitelist
+  - ``HMAN_LLM_ENDPOINT``         Ollama-compatible chat endpoint
+                                  (default: http://localhost:11434/api/chat)
+  - ``HMAN_LLM_MODEL``            default: ``llama3.2:3b``
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+import requests
+
+from .pact import render_attestation_block
+from .types import ExecutionResult, Intention, PACTAttestation
+
+
+_DRAFT_SYSTEM_PROMPT = """You are HMAN's drafting subconscious. The member casually mentioned a bug or feature request in conversation. Turn what they said into a concise, actionable GitHub issue.
+
+Output ONLY a JSON object on a single line with two keys: "title" and "body".
+
+Rules:
+- "title" is under 70 chars, imperative mood, no trailing period.
+- "body" is plain Markdown. Open with one sentence stating the problem or request from the member's point of view, then a short "## Context" section quoting their actual words verbatim.
+- Don't fabricate symptoms, error messages, or stack traces the member didn't say.
+- Don't add labels, milestones, or assignees - the LLM does NOT auto-categorize.
+- Don't include any HMAN attestation block - that's appended separately.
+"""
+
+
+@dataclass
+class GitHubConnectorConfig:
+    default_owner: str
+    default_repo: str
+    allowed_repos: Optional[list[tuple[str, str]]] = None
+    llm_endpoint: str = "http://localhost:11434/api/chat"
+    llm_model: str = "llama3.2:3b"
+    token: Optional[str] = None
+    api_base: str = "https://api.github.com"
+
+    @classmethod
+    def from_env(cls) -> "GitHubConnectorConfig":
+        allowed_raw = os.environ.get("HMAN_GITHUB_ALLOWED_REPOS", "").strip()
+        allowed: Optional[list[tuple[str, str]]] = None
+        if allowed_raw:
+            allowed = []
+            for entry in allowed_raw.split(","):
+                entry = entry.strip()
+                if "/" in entry:
+                    owner, repo = entry.split("/", 1)
+                    allowed.append((owner.strip(), repo.strip()))
+        return cls(
+            default_owner=os.environ.get("HMAN_GITHUB_DEFAULT_OWNER", "Tailor-AUS"),
+            default_repo=os.environ.get(
+                "HMAN_GITHUB_DEFAULT_REPO", "Human-Managed-Access-Network"
+            ),
+            allowed_repos=allowed,
+            llm_endpoint=os.environ.get("HMAN_LLM_ENDPOINT", "http://localhost:11434/api/chat"),
+            llm_model=os.environ.get("HMAN_LLM_MODEL", "llama3.2:3b"),
+            token=os.environ.get("HMAN_GITHUB_TOKEN") or None,
+        )
+
+
+def parse_draft_reply(reply: str, context: str) -> tuple[str, str]:
+    """Extract ``{title, body}`` from an LLM reply.
+
+    Mirrors the TypeScript ``parseDraftReply`` — falls back to a stub
+    issue using the raw context if parsing fails so we never silently
+    drop the member's words.
+    """
+    # Find the first {...} JSON-shaped substring.
+    start = reply.find("{")
+    end = reply.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            parsed = json.loads(reply[start : end + 1])
+            title = parsed.get("title")
+            body = parsed.get("body")
+            if isinstance(title, str) and title.strip() and isinstance(body, str) and body.strip():
+                return (title.strip()[:120], body.strip())
+        except Exception:
+            pass
+
+    trimmed = re.sub(r"\s+", " ", context.strip())
+    title = (trimmed[:67] + "...") if len(trimmed) > 70 else (trimmed or "Untitled issue from voice draft")
+    body = (
+        f"## Context\n\n> {trimmed or '(no context captured)'}\n\n"
+        "_Drafted by HMAN - the LLM did not return a structured response, "
+        "so this is a verbatim quote of the member's words._"
+    )
+    return (title, body)
+
+
+class GitHubConnector:
+    """Mirror of ``GitHubConnector`` (TS). ``draft`` + ``execute`` + ``undo``."""
+
+    name = "github"
+
+    def __init__(
+        self,
+        config: Optional[GitHubConnectorConfig] = None,
+        *,
+        llm_chat: Optional[Callable[[str, str], str]] = None,
+        http_post: Optional[Callable[..., Any]] = None,
+        http_patch: Optional[Callable[..., Any]] = None,
+        now: Optional[Callable[[], datetime]] = None,
+    ):
+        self.config = config or GitHubConnectorConfig.from_env()
+        self._llm_chat = llm_chat or self._default_llm_chat
+        self._http_post = http_post or requests.post
+        self._http_patch = http_patch or requests.patch
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    # ── default LLM call ────────────────────────────────────────────
+
+    def _default_llm_chat(self, system: str, user: str) -> str:
+        res = requests.post(
+            self.config.llm_endpoint,
+            json={
+                "model": self.config.llm_model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                "stream": False,
+                "options": {"temperature": 0.2},
+            },
+            timeout=60,
+        )
+        res.raise_for_status()
+        data = res.json()
+        return (data.get("message") or {}).get("content", "").strip()
+
+    # ── draft ───────────────────────────────────────────────────────
+
+    def draft(self, *, context: str, member_id: Optional[str] = None) -> Intention:
+        try:
+            reply = self._llm_chat(_DRAFT_SYSTEM_PROMPT, context)
+        except Exception:
+            reply = ""  # fall through to stub
+        title, body = parse_draft_reply(reply, context)
+        # ``member_id`` reserved for future routing; not yet used in
+        # default-repo selection.
+        _ = member_id
+        return Intention(
+            id=str(uuid.uuid4()),
+            connector=self.name,
+            action="issue.create",
+            payload={
+                "owner": self.config.default_owner,
+                "repo": self.config.default_repo,
+                "title": title,
+                "body": body,
+            },
+            description=f'File a GitHub issue: "{title}"',
+            urgency=0.3,
+            context=context,
+            drafted_at=self._now().isoformat(),
+        )
+
+    # ── execute ─────────────────────────────────────────────────────
+
+    def execute(self, intention: Intention, attestation: PACTAttestation) -> ExecutionResult:
+        from .pact import hash_intention
+
+        expected = hash_intention(intention)
+        if attestation.intention_hash != expected:
+            return ExecutionResult(
+                success=False,
+                attestation=attestation,
+                error=(
+                    f"attestation/intention hash mismatch "
+                    f"(expected {expected}, got {attestation.intention_hash})"
+                ),
+            )
+
+        owner = intention.payload.get("owner")
+        repo = intention.payload.get("repo")
+        title = intention.payload.get("title")
+        body = intention.payload.get("body")
+        if not (owner and repo and title and body):
+            return ExecutionResult(
+                success=False,
+                attestation=attestation,
+                error="payload missing owner/repo/title/body",
+            )
+
+        if self.config.allowed_repos and (owner, repo) not in self.config.allowed_repos:
+            return ExecutionResult(
+                success=False,
+                attestation=attestation,
+                error=f"repo {owner}/{repo} not in allowed_repos whitelist",
+            )
+
+        token = self.config.token
+        if not token:
+            return ExecutionResult(
+                success=False,
+                attestation=attestation,
+                error=(
+                    "HMAN_GITHUB_TOKEN not set - cannot call GitHub. "
+                    "Use a fine-grained PAT with issues:write on the whitelisted repo."
+                ),
+            )
+
+        composed_body = f"{body.strip()}\n\n{render_attestation_block(attestation)}\n"
+        url = f"{self.config.api_base}/repos/{owner}/{repo}/issues"
+        try:
+            res = self._http_post(
+                url,
+                json={"title": title, "body": composed_body},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                timeout=30,
+            )
+        except Exception as e:
+            return ExecutionResult(success=False, attestation=attestation, error=str(e))
+
+        if not getattr(res, "ok", False):
+            text = getattr(res, "text", "")[:200]
+            return ExecutionResult(
+                success=False,
+                attestation=attestation,
+                error=f"GitHub issue create failed: {res.status_code} {text}",
+            )
+
+        data = res.json()
+        return ExecutionResult(
+            success=True,
+            attestation=attestation,
+            artifact_url=data.get("html_url"),
+            artifact_id=f"{owner}/{repo}#{data.get('number')}",
+        )
+
+    # ── undo ────────────────────────────────────────────────────────
+
+    def undo(self, result: ExecutionResult) -> None:
+        if not result.success or not result.artifact_id:
+            return
+        m = re.match(r"^([^/]+)/([^#]+)#(\d+)$", result.artifact_id)
+        if not m:
+            raise RuntimeError(f"cannot parse artifact_id for undo: {result.artifact_id}")
+        owner, repo, num = m.group(1), m.group(2), int(m.group(3))
+        token = self.config.token
+        if not token:
+            raise RuntimeError("HMAN_GITHUB_TOKEN not set")
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        # Post a "rescinded" comment, then close the issue.
+        comment_url = f"{self.config.api_base}/repos/{owner}/{repo}/issues/{num}/comments"
+        self._http_post(
+            comment_url,
+            json={
+                "body": (
+                    "Closed by HMAN: member rescinded consent for this action. "
+                    "Original PACT attestation in the issue body remains valid history."
+                )
+            },
+            headers=headers,
+            timeout=30,
+        )
+        close_url = f"{self.config.api_base}/repos/{owner}/{repo}/issues/{num}"
+        self._http_patch(
+            close_url,
+            json={"state": "closed", "state_reason": "not_planned"},
+            headers=headers,
+            timeout=30,
+        )

--- a/packages/python-bridge/connectors/pact.py
+++ b/packages/python-bridge/connectors/pact.py
@@ -1,0 +1,147 @@
+"""PACT attestation primitives — sign + canonicalise.
+
+The signing key is loaded from disk in ``~/.hman/identity/pact_ed25519.pem``.
+If the file doesn't exist we generate a new keypair and persist it. This
+key represents the member's identity for purposes of authorising external
+actions; rotating it is a destructive step that breaks all prior issue
+attestations, so the file is created with mode 0600 and never re-derived
+from the passphrase.
+
+The canonical bytes the signature commits to are:
+
+    JSON({
+        "memberId":      <str>,
+        "intentionHash": <hex sha256 of canonical intention>,
+        "channel":       "voice" | "text" | "queue",
+        "timestamp":     <ISO-8601>,
+    })
+
+Hash of the intention itself uses a stable JSON encoding that mirrors
+the TypeScript ``hashIntention`` helper.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from base64 import b64encode
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from .types import Intention, PACTAttestation
+
+
+# Resolve ~/.hman/identity once.
+_DATA_ENV = os.environ.get("HMAN_DATA_DIR")
+_HMAN_DIR = Path(_DATA_ENV).expanduser().resolve() if _DATA_ENV else Path.home() / ".hman"
+_IDENTITY_DIR = _HMAN_DIR / "identity"
+_PACT_KEY_FILE = _IDENTITY_DIR / "pact_ed25519.pem"
+
+
+def _ensure_keypair() -> tuple[Ed25519PrivateKey, Ed25519PublicKey, str]:
+    """Load (or generate) the member's PACT signing keypair.
+
+    Returns the private key, the public key, and the PEM-encoded public
+    key (UTF-8 string) for embedding in attestations.
+    """
+    _IDENTITY_DIR.mkdir(parents=True, exist_ok=True)
+    if _PACT_KEY_FILE.exists():
+        pem = _PACT_KEY_FILE.read_bytes()
+        priv = serialization.load_pem_private_key(pem, password=None)
+        if not isinstance(priv, Ed25519PrivateKey):
+            raise RuntimeError(f"{_PACT_KEY_FILE} is not an Ed25519 private key")
+    else:
+        priv = Ed25519PrivateKey.generate()
+        pem = priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        # Restrictive perms; on Windows os.chmod is best-effort only.
+        _PACT_KEY_FILE.write_bytes(pem)
+        try:
+            os.chmod(_PACT_KEY_FILE, 0o600)
+        except Exception:
+            pass
+
+    pub = priv.public_key()
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return priv, pub, pub_pem
+
+
+def hash_intention(intention: Intention) -> str:
+    """Deterministic hash of an Intention. Mirrors the TS ``hashIntention``."""
+    stable = {
+        "id": intention.id,
+        "connector": intention.connector,
+        "action": intention.action,
+        "payload": intention.payload,
+        "description": intention.description,
+        "urgency": intention.urgency,
+        "context": intention.context if intention.context is not None else None,
+        "draftedAt": intention.drafted_at,
+    }
+    canonical = json.dumps(stable, separators=(",", ":"), sort_keys=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def sign_attestation(
+    intention: Intention,
+    member_id: str,
+    channel: str,
+    *,
+    timestamp: Optional[str] = None,
+) -> PACTAttestation:
+    """Sign a PACT attestation for the given Intention + consent moment."""
+    priv, _pub, pub_pem = _ensure_keypair()
+    intention_hash = hash_intention(intention)
+    ts = timestamp or datetime.now(timezone.utc).isoformat()
+    canonical = json.dumps(
+        {
+            "memberId": member_id,
+            "intentionHash": intention_hash,
+            "channel": channel,
+            "timestamp": ts,
+        },
+        separators=(",", ":"),
+        sort_keys=False,
+    )
+    sig = priv.sign(canonical.encode("utf-8"))
+    return PACTAttestation(
+        member_id=member_id,
+        intention_hash=intention_hash,
+        channel=channel,
+        timestamp=ts,
+        public_key=b64encode(pub_pem.encode("utf-8")).decode("ascii"),
+        signature=b64encode(sig).decode("ascii"),
+    )
+
+
+def render_attestation_block(attestation: PACTAttestation) -> str:
+    """Render an attestation as a collapsed Markdown ``<details>`` block."""
+    pretty = json.dumps(attestation.to_dict(), indent=2)
+    return "\n".join(
+        [
+            "",
+            "<!-- HMAN PACT attestation — verifies this issue was an authorized member action. -->",
+            "<details>",
+            "<summary>HMAN PACT attestation</summary>",
+            "",
+            "```json",
+            pretty,
+            "```",
+            "",
+            "_Verify this signature with the public key above against the canonical hash of the issue payload._",
+            "</details>",
+        ]
+    )

--- a/packages/python-bridge/connectors/store.py
+++ b/packages/python-bridge/connectors/store.py
@@ -1,0 +1,65 @@
+"""Tiny on-disk Intention store.
+
+Drafted intentions can sit for 30+ minutes waiting for a receptive
+moment. Holding them in memory means a bridge crash drops them — the
+spec says: persist.
+
+Stored at ``~/.hman/connector_intentions/<id>.json``. One file per
+intention, atomic write-then-rename. The store is intentionally tiny
+(no SQLite dep, no schema migration) — connectors don't need much.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from .types import Intention
+
+_DATA_ENV = os.environ.get("HMAN_DATA_DIR")
+_HMAN_DIR = Path(_DATA_ENV).expanduser().resolve() if _DATA_ENV else Path.home() / ".hman"
+_STORE_DIR = _HMAN_DIR / "connector_intentions"
+
+
+def _path_for(intention_id: str) -> Path:
+    # intention_id is a uuid (we generated it) so it's path-safe; still
+    # belt-and-braces strip any path separators just in case.
+    safe = intention_id.replace("/", "_").replace("\\", "_")
+    return _STORE_DIR / f"{safe}.json"
+
+
+def save(intention: Intention) -> None:
+    _STORE_DIR.mkdir(parents=True, exist_ok=True)
+    data = intention.to_dict()
+    fd, tmp = tempfile.mkstemp(dir=str(_STORE_DIR), suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp, str(_path_for(intention.id)))
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except Exception:
+            pass
+        raise
+
+
+def load(intention_id: str) -> Optional[Intention]:
+    path = _path_for(intention_id)
+    if not path.exists():
+        return None
+    try:
+        return Intention.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except Exception:
+        return None
+
+
+def delete(intention_id: str) -> None:
+    path = _path_for(intention_id)
+    if path.exists():
+        try:
+            path.unlink()
+        except Exception:
+            pass

--- a/packages/python-bridge/connectors/types.py
+++ b/packages/python-bridge/connectors/types.py
@@ -1,0 +1,104 @@
+"""Connector wire shapes (mirrors ``packages/core/src/connectors/Connector.ts``).
+
+These are plain dataclasses — they serialise to/from JSON via
+``dataclasses.asdict`` and ``cls(**data)``. Keep field names aligned
+with the TypeScript contract or attestations won't verify across
+languages.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Optional
+
+
+# ── PACT attestation ────────────────────────────────────────────────
+
+
+@dataclass
+class PACTAttestation:
+    """Proof a connector embeds alongside the external action."""
+
+    member_id: str
+    intention_hash: str
+    channel: str  # "voice" | "text" | "queue"
+    timestamp: str
+    public_key: str  # base64 of the PEM-encoded Ed25519 public key
+    signature: str  # base64 of the raw Ed25519 signature
+
+    def to_dict(self) -> dict[str, Any]:
+        # Camel-case for JSON parity with the TypeScript shape.
+        return {
+            "memberId": self.member_id,
+            "intentionHash": self.intention_hash,
+            "channel": self.channel,
+            "timestamp": self.timestamp,
+            "publicKey": self.public_key,
+            "signature": self.signature,
+        }
+
+
+# ── Intention ───────────────────────────────────────────────────────
+
+
+@dataclass
+class Intention:
+    """What HMAN is *thinking about* doing, before consent.
+
+    ``payload`` is connector-specific. For GitHub it's
+    ``{"owner": ..., "repo": ..., "title": ..., "body": ...}``.
+    """
+
+    id: str
+    connector: str
+    action: str
+    payload: dict[str, Any]
+    description: str
+    urgency: float
+    drafted_at: str
+    context: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "connector": self.connector,
+            "action": self.action,
+            "payload": self.payload,
+            "description": self.description,
+            "urgency": self.urgency,
+            "context": self.context,
+            "draftedAt": self.drafted_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Intention":
+        return cls(
+            id=data["id"],
+            connector=data["connector"],
+            action=data["action"],
+            payload=data["payload"],
+            description=data["description"],
+            urgency=float(data["urgency"]),
+            context=data.get("context"),
+            drafted_at=data.get("draftedAt") or data.get("drafted_at") or "",
+        )
+
+
+# ── ExecutionResult ─────────────────────────────────────────────────
+
+
+@dataclass
+class ExecutionResult:
+    success: bool
+    attestation: PACTAttestation
+    artifact_url: Optional[str] = None
+    artifact_id: Optional[str] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "success": self.success,
+            "artifactUrl": self.artifact_url,
+            "artifactId": self.artifact_id,
+            "attestation": self.attestation.to_dict(),
+            "error": self.error,
+        }

--- a/packages/python-bridge/tests/test_connectors.py
+++ b/packages/python-bridge/tests/test_connectors.py
@@ -1,0 +1,269 @@
+"""
+Tests for the Python connector subsystem.
+
+These mirror the TS tests in ``packages/core/src/__tests__/connectors.test.ts``
+and additionally cover the on-disk Intention store and PACT signing
+round-trips.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from base64 import b64decode
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make sibling module importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture(autouse=True)
+def isolate_hman_dir(tmp_path, monkeypatch):
+    """Every test gets a fresh HMAN_DATA_DIR so they can't observe each other's state."""
+    monkeypatch.setenv("HMAN_DATA_DIR", str(tmp_path))
+    # Reload the modules that cache the resolved path at import time.
+    for mod in list(sys.modules):
+        if mod.startswith("connectors"):
+            del sys.modules[mod]
+    yield
+
+
+def test_hash_intention_deterministic():
+    from connectors.types import Intention
+    from connectors.pact import hash_intention
+
+    i = Intention(
+        id="i1",
+        connector="github",
+        action="issue.create",
+        payload={"owner": "x", "repo": "y", "title": "t", "body": "b"},
+        description="d",
+        urgency=0.3,
+        drafted_at="2026-04-26T00:00:00+00:00",
+    )
+    assert hash_intention(i) == hash_intention(i)
+
+
+def test_hash_intention_changes_when_payload_changes():
+    from connectors.types import Intention
+    from connectors.pact import hash_intention
+
+    i1 = Intention(
+        id="i1", connector="github", action="issue.create",
+        payload={"owner": "x", "repo": "y", "title": "t", "body": "b"},
+        description="d", urgency=0.3, drafted_at="t",
+    )
+    i2 = Intention(
+        id="i1", connector="github", action="issue.create",
+        payload={"owner": "x", "repo": "y", "title": "t2", "body": "b"},
+        description="d", urgency=0.3, drafted_at="t",
+    )
+    assert hash_intention(i1) != hash_intention(i2)
+
+
+def test_sign_attestation_round_trips():
+    from connectors.types import Intention
+    from connectors.pact import sign_attestation, hash_intention
+    from cryptography.hazmat.primitives import serialization
+
+    i = Intention(
+        id="i1", connector="github", action="issue.create",
+        payload={"owner": "x", "repo": "y", "title": "t", "body": "b"},
+        description="d", urgency=0.3, drafted_at="t",
+    )
+    att = sign_attestation(i, member_id="member-abc", channel="voice")
+    assert att.intention_hash == hash_intention(i)
+
+    # Re-derive canonical bytes and verify with the embedded public key.
+    canonical = json.dumps(
+        {
+            "memberId": "member-abc",
+            "intentionHash": att.intention_hash,
+            "channel": "voice",
+            "timestamp": att.timestamp,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    pem = b64decode(att.public_key.encode()).decode("utf-8")
+    pub = serialization.load_pem_public_key(pem.encode())
+    pub.verify(b64decode(att.signature.encode()), canonical)  # raises on failure
+
+
+def test_parse_draft_reply_well_formed_json():
+    from connectors.github import parse_draft_reply
+
+    title, body = parse_draft_reply(
+        '{"title":"Fix Muse handshake","body":"## Context\\n> handshake fails"}',
+        "irrelevant context",
+    )
+    assert title == "Fix Muse handshake"
+    assert "handshake fails" in body
+
+
+def test_parse_draft_reply_extracts_json_from_prose():
+    from connectors.github import parse_draft_reply
+
+    title, body = parse_draft_reply(
+        'Sure, here is your draft:\n{"title":"X","body":"Y"}\nGood luck!',
+        "ctx",
+    )
+    assert title == "X"
+    assert body == "Y"
+
+
+def test_parse_draft_reply_falls_back_on_garbage():
+    from connectors.github import parse_draft_reply
+
+    title, body = parse_draft_reply(
+        "this is just words with no JSON whatsoever",
+        "the muse handshake is annoying",
+    )
+    assert title  # non-empty
+    assert "muse handshake is annoying" in body
+
+
+def test_intention_store_persists_and_loads():
+    from connectors.types import Intention
+    from connectors import store as intention_store
+
+    i = Intention(
+        id="abc-123", connector="github", action="issue.create",
+        payload={"owner": "x", "repo": "y", "title": "t", "body": "b"},
+        description="d", urgency=0.3, drafted_at="t",
+    )
+    intention_store.save(i)
+    loaded = intention_store.load("abc-123")
+    assert loaded is not None
+    assert loaded.id == "abc-123"
+    assert loaded.payload["title"] == "t"
+
+    intention_store.delete("abc-123")
+    assert intention_store.load("abc-123") is None
+
+
+def test_github_connector_draft_returns_typed_intention():
+    from connectors.github import GitHubConnector, GitHubConnectorConfig
+
+    config = GitHubConnectorConfig(default_owner="example", default_repo="repo", token="dummy")
+    connector = GitHubConnector(
+        config=config,
+        llm_chat=lambda system, user: '{"title":"Fix it","body":"It is broken."}',
+    )
+    intention = connector.draft(context="this thing is broken")
+    assert intention.connector == "github"
+    assert intention.action == "issue.create"
+    assert intention.payload["owner"] == "example"
+    assert intention.payload["repo"] == "repo"
+    assert intention.payload["title"] == "Fix it"
+    assert 0 < intention.urgency <= 1
+    assert intention.id  # uuid
+
+
+def test_github_connector_execute_rejects_hash_mismatch():
+    from connectors.github import GitHubConnector, GitHubConnectorConfig
+    from connectors.pact import sign_attestation
+
+    config = GitHubConnectorConfig(default_owner="example", default_repo="repo", token="dummy")
+    connector = GitHubConnector(
+        config=config,
+        llm_chat=lambda system, user: '{"title":"X","body":"Y"}',
+    )
+    intention = connector.draft(context="ctx")
+    attestation = sign_attestation(intention, member_id="m", channel="voice")
+    # Tamper after signing
+    intention.payload["title"] = "tampered"
+    result = connector.execute(intention, attestation)
+    assert not result.success
+    assert "hash mismatch" in (result.error or "")
+
+
+def test_github_connector_execute_rejects_unwhitelisted_repo():
+    from connectors.github import GitHubConnector, GitHubConnectorConfig
+    from connectors.pact import sign_attestation
+
+    config = GitHubConnectorConfig(
+        default_owner="example",
+        default_repo="repo",
+        token="dummy",
+        allowed_repos=[("allowed", "thing")],
+    )
+    connector = GitHubConnector(
+        config=config,
+        llm_chat=lambda system, user: '{"title":"X","body":"Y"}',
+    )
+    intention = connector.draft(context="ctx")
+    attestation = sign_attestation(intention, member_id="m", channel="voice")
+    result = connector.execute(intention, attestation)
+    assert not result.success
+    assert "whitelist" in (result.error or "")
+
+
+def test_github_connector_execute_embeds_attestation_in_body():
+    from connectors.github import GitHubConnector, GitHubConnectorConfig
+    from connectors.pact import sign_attestation
+
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["body"] = json["body"]
+        m = MagicMock()
+        m.ok = True
+        m.status_code = 201
+        m.json.return_value = {"number": 42, "html_url": "https://github.com/example/repo/issues/42"}
+        return m
+
+    config = GitHubConnectorConfig(default_owner="example", default_repo="repo", token="real-token")
+    connector = GitHubConnector(
+        config=config,
+        llm_chat=lambda system, user: '{"title":"X","body":"Y"}',
+        http_post=fake_post,
+    )
+    intention = connector.draft(context="ctx")
+    attestation = sign_attestation(intention, member_id="m", channel="voice")
+    result = connector.execute(intention, attestation)
+    assert result.success
+    assert result.artifact_url == "https://github.com/example/repo/issues/42"
+    assert result.artifact_id == "example/repo#42"
+    assert "<details>" in captured["body"]
+    assert "HMAN PACT attestation" in captured["body"]
+    assert attestation.signature in captured["body"]
+
+
+def test_github_connector_execute_returns_error_when_token_missing():
+    from connectors.github import GitHubConnector, GitHubConnectorConfig
+    from connectors.pact import sign_attestation
+
+    config = GitHubConnectorConfig(default_owner="example", default_repo="repo", token=None)
+    connector = GitHubConnector(
+        config=config,
+        llm_chat=lambda system, user: '{"title":"X","body":"Y"}',
+    )
+    intention = connector.draft(context="ctx")
+    attestation = sign_attestation(intention, member_id="m", channel="voice")
+    result = connector.execute(intention, attestation)
+    assert not result.success
+    assert "HMAN_GITHUB_TOKEN not set" in (result.error or "")
+
+
+def test_audit_append_event_writes_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setenv("HMAN_DATA_DIR", str(tmp_path))
+    # reload audit so it picks up new env
+    for mod in list(sys.modules):
+        if mod.startswith("connectors"):
+            del sys.modules[mod]
+    from connectors.audit import append_event
+
+    append_event("drafted", intention_id="i1", connector="github", member_id="m")
+    log = tmp_path / "logs" / "connector_events.jsonl"
+    assert log.exists()
+    lines = log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["event"] == "drafted"
+    assert rec["intention_id"] == "i1"
+    assert rec["connector"] == "github"
+    assert rec["member_id"] == "m"


### PR DESCRIPTION
Fixes #20. Depends on #4 / PR #5.

## What this is

The first concrete external action HMAN takes on a member's behalf, and the template every future connector (Bank, Tailor, Calendar, email, Slack) inherits.

```
voice mentions a bug -> LLM drafts an issue -> receptivity gate
decides when to surface it -> on consent Y, the connector calls
GitHub's REST API with a PACT attestation embedded so the issue is
verifiably an authorized member action
```

## The abstraction

`packages/core/src/connectors/Connector.ts` is the load-bearing piece — every future connector implements the same shape, so the gate, consent UI, audit log, and undo path can treat them uniformly:

```ts
interface Connector<TPayload = unknown> {
  readonly name: string;
  draft(input: { context: string; memberId?: string }): Promise<Intention<TPayload>>;
  execute(intention: Intention<TPayload>, attestation: PACTAttestation): Promise<ExecutionResult>;
  undo?(result: ExecutionResult): Promise<void>;
}
```

`Intention` carries a typed payload + `urgency` + `context` so the receptivity gate can quote the member back to themselves. `PACTAttestation` is a plain JSON envelope (`memberId`, `intentionHash`, `channel`, `timestamp`, `publicKey`, `signature`) that embeds inline alongside the artifact so it's verifiable without HMAN-side tooling.

## GitHub implementation

`packages/core/src/connectors/github.ts` and a Python mirror in `packages/python-bridge/connectors/`:

- `draft()` calls Ollama (`llama3.2:3b` by default) with a tight system prompt asking for `{title, body}` JSON. Falls back to a stub issue quoting the member's words verbatim if the LLM returns garbage — better to file something than to silently drop a bug report.
- `execute()` cross-checks the attestation hash against the intention (so a tampered intention can't be executed under an old signature), enforces a `HMAN_GITHUB_ALLOWED_REPOS` whitelist, then appends the attestation as a collapsed `<details>` block at the end of the issue body before POSTing to GitHub.
- `undo()` closes the issue with a "rescinded by member" comment. Issues are low blast radius so undo is safe; the original attestation in the body remains as public history.
- Repo whitelist + fine-grained PAT (`issues:write` only) — no classic `repo` tokens.

## Bridge endpoints

`packages/python-bridge/api/connectors.py` registers four routes:

- `POST /api/connectors/github/draft`
- `POST /api/connectors/github/execute`
- `GET  /api/connectors/github/intentions`
- `DELETE /api/connectors/github/intentions/{id}`

All four require Gate-5 freshness (last successful biometric activation within 60s). The bridge wires the freshness check at startup; if it's not configured the endpoints fail closed with 503.

Drafts persist to `~/.hman/connector_intentions/<id>.json` (atomic write-then-rename) so a 30-min wait for a receptive moment can survive a bridge crash. Every step appends a line to `~/.hman/logs/connector_events.jsonl` (drafted / decided / executed / failed).

## Receptivity-gate dependency

#4 / PR #5 isn't merged yet. To stay decoupled:

- `packages/core/src/connectors/Connector.ts` defines a thin TS `ReceptivityGate` interface that the connector code imports. Tests inject stubs.
- The Python bridge imports the canonical `receptivity` module from PR #5 by name in `api/connectors.py` once #5 merges — no refactor needed in connector code.

When #5 lands, a small follow-up PR will narrow the TS interface to whatever shape #5 settles on.

## Validation

- `npm run typecheck` clean across `packages/core`
- 16 vitest tests in `packages/core/src/__tests__/connectors.test.ts` (hash determinism, Ed25519 round-trip, attestation block render, draft JSON-extraction + fallback, hash-mismatch rejection, whitelist rejection, REST-error path, undo close-with-comment)
- 13 pytest tests in `packages/python-bridge/tests/test_connectors.py` (full mirror)
- `python -m py_compile api/server.py api/connectors.py connectors/*.py` clean
- Cross-language: TS `hashIntention` and Python `hash_intention` produce byte-for-byte identical SHA-256 hashes over the same Intention. JSON canonicalisation is fixed-key-order with `(",",":")` separators in both languages.

## Demo doc

`docs/demos/github-connector-loop.md` walks through speaking a bug, the gate surfacing the consent moment, signing the attestation, and the issue landing on GitHub — with curl recipes for each bridge endpoint so contributors can test pieces independently. Also covers the fine-grained-PAT onboarding flow and a troubleshooting table.

## Out of scope (per the issue)

- Voice editing of drafts (post-v0; manual edit via dashboard for now)
- LLM auto-categorisation/labelling — issue body is the LLM's call
- Multi-repo routing logic — single configured target repo for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)