### PR TITLE
feat(ios): HealthKit reads → receptivity signals

### DIFF
--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -45,7 +45,15 @@ let package = Package(
                 .product(name: "Clibsodium", package: "swift-sodium"),
                 .product(name: "KeychainAccess", package: "KeychainAccess"),
             ],
-            path: "Sources/HMAN"
+            path: "Sources/HMAN",
+            // Info.plist + entitlements are consumed by the host
+            // .xcodeproj / xcodebuild layer (#16 onward), not by the
+            // SwiftPM library itself. Exclude them so `swift build`
+            // doesn't try to copy them as resources.
+            exclude: [
+                "Resources/Info.plist",
+                "HMAN.entitlements",
+            ]
         ),
         .testTarget(
             name: "HMANTests",

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -16,11 +16,16 @@ apps/ios/
 ├── Sources/HMAN/
 │   ├── HMANApp.swift                   @main SwiftUI entry
 │   ├── ContentView.swift               TabView shell
+│   ├── HMAN.entitlements               capabilities (HealthKit; xcodeproj-consumed)
 │   ├── Bridge/HMANBridgeClient.swift   typed FastAPI wrapper, BridgeError
 │   ├── Models/                         Codable ports of shared TS types
+│   ├── Receptivity/HealthKitSignal.swift   HealthKit → (score, confidence, reason)
+│   ├── Resources/Info.plist            NSHealthShareUsageDescription
+│   ├── Sensors/HealthKitProvider.swift HKHealthStore wrapper, async API
 │   └── Views/                          placeholder routes (Welcome, ...)
 └── Tests/HMANTests/
-    └── HMANBridgeClientTests.swift     URL-construction + decoder tests
+    ├── HMANBridgeClientTests.swift     URL-construction + decoder tests
+    └── HealthKitSignalTests.swift      receptivity-heuristic coverage
 ```
 
 ## Requirements
@@ -64,7 +69,19 @@ A future PR (after the chassis is in `main`) will add either:
 - An `.xcodeproj` alongside `Package.swift` so signing config and Info.plist entitlements travel in the repo, or
 - A scripted `xcodebuild`-driven flow that injects a member-supplied team ID at build time.
 
-For now: open `Package.swift` in Xcode, select the **HMAN** scheme, choose your physical device, and let Xcode prompt for code-signing setup. iCloud / push / HealthKit entitlements arrive with their respective Wave 2 issues — the skeleton has none.
+For now: open `Package.swift` in Xcode, select the **HMAN** scheme, choose your physical device, and let Xcode prompt for code-signing setup. iCloud / push entitlements arrive with their respective Wave 2 issues. HealthKit landed in #16 — see below.
+
+## HealthKit (issue #16)
+
+`HealthKitProvider` wraps `HKHealthStore` with an async surface and exposes four reads: `currentHR()`, `recentHRV()` (SDNN, last 5 min), `motionStateNow()` (steps + active energy in last 60 s), and `sleepLastNight()`. It also computes rolling 7-day baselines (`baselineHRMean`, `baselineHRVMean`) used by the receptivity adapter.
+
+`HealthKitSignal.compute(_:)` consumes a `HealthKitProviding` and emits a `(score, confidence, reason)` tuple ranging `score ∈ [-1.0, +1.0]` (negative = don't interrupt, positive = OK). Four heuristic branches: HR-elevated-while-still → stressed; low HRV → recovery; both vitals at baseline → calm; otherwise unknown.
+
+**Privacy:** raw HR / HRV / step / sleep values never leave `HealthKitProvider`. Only the `ReceptivityScore` tuple is exposed to the rest of HMAN.
+
+**Polling:** default 60 s, configurable via `HealthKitProvider(pollInterval:)`. Call `start()` on appear, `stop()` on disappear.
+
+**Entitlements:** `Sources/HMAN/HMAN.entitlements` declares the HealthKit capability (`com.apple.developer.healthkit`). `Sources/HMAN/Resources/Info.plist` carries the `NSHealthShareUsageDescription` shown in the iOS permission sheet. Both files are excluded from the SwiftPM build (consumed by the .xcodeproj / xcodebuild layer once we add one); `swift build` and `swift test` continue to compile cleanly without HealthKit linkage on Linux CI hosts.
 
 ## Bridge configuration
 

--- a/apps/ios/Sources/HMAN/HMAN.entitlements
+++ b/apps/ios/Sources/HMAN/HMAN.entitlements
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+		HealthKit capability. Required by the runtime check in
+		HealthKitProvider.requestAuthorization(). Read-only — HMAN
+		never writes to HealthKit, so we don't need the
+		health-records key.
+
+		Background delivery (`com.apple.developer.healthkit.background-delivery`)
+		is intentionally omitted; the receptivity gate polls on a
+		60-second cadence while the app is foregrounded, which is
+		enough for v1. A follow-up PR can add background delivery
+		once we have a clearer story for member-controlled cadence.
+	-->
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/ios/Sources/HMAN/Receptivity/HealthKitSignal.swift
+++ b/apps/ios/Sources/HMAN/Receptivity/HealthKitSignal.swift
@@ -1,0 +1,129 @@
+// HealthKitSignal.swift — adapter from HealthKit readings to the
+// receptivity gate's `(score, confidence, reason)` contract.
+//
+// The receptivity gate (#4, see packages/python-bridge/receptivity)
+// composes signals from many sources. Each source emits a normalised
+// triple:
+//
+//     score:      [-1.0 ... +1.0]   negative = don't interrupt, positive = interrupt freely
+//     confidence: [ 0.0 ...  1.0]   how much weight to give this signal
+//     reason:     short whisperable string the gate may surface verbally
+//
+// Note: the iOS-side adapter uses the [-1, +1] range from issue #16;
+// the Python bridge currently uses [0, 1]. The bridge will rescale
+// when these signals reach it — keeping the iOS contract symmetric
+// makes "don't interrupt" vs "interrupt" semantics explicit.
+//
+// The four heuristic branches we implement match the issue body
+// exactly; thresholds are intentionally conservative because we'd
+// rather under-interrupt than nag a stressed member.
+
+import Foundation
+
+// ── Public contract ────────────────────────────────────────────────
+
+/// One normalised signal contribution toward the gate's composite
+/// receptivity decision. Treated as Sendable so it can cross actor
+/// boundaries (e.g. from `@MainActor` UI into a background bridge
+/// uploader without copies).
+public struct ReceptivityScore: Sendable, Equatable {
+    /// -1.0 = "definitely don't interrupt"; +1.0 = "go ahead". Zero
+    /// is neutral / no information.
+    public let score: Double
+    /// 0.0 = ignore me; 1.0 = trust me fully. The gate multiplies
+    /// score * confidence when blending.
+    public let confidence: Double
+    /// Member-facing one-liner. Kept short enough to whisper through
+    /// TTS without cutting into the daily voice-word budget.
+    public let reason: String
+
+    public init(score: Double, confidence: Double, reason: String) {
+        // Clamp at the boundary in case a future heuristic over-shoots.
+        self.score = max(-1.0, min(1.0, score))
+        self.confidence = max(0.0, min(1.0, confidence))
+        self.reason = reason
+    }
+
+    /// Sentinel for "nothing useful to say" — confidence zero so the
+    /// gate ignores it, neutral score, neutral reason.
+    public static let unknown = ReceptivityScore(
+        score: 0,
+        confidence: 0,
+        reason: "no autonomic data"
+    )
+}
+
+// ── Heuristic logic ────────────────────────────────────────────────
+
+/// Stateless adapter. Given the latest readings on a `HealthKitProviding`,
+/// compute a single `ReceptivityScore`. No side effects, no I/O —
+/// trivially testable with a mock provider.
+public enum HealthKitSignal {
+    /// Branch order matters: more specific stress conditions first,
+    /// then post-effort recovery, then the calm-baseline boost. Once
+    /// any branch matches we return — composition with other signals
+    /// happens in the gate, not here.
+    ///
+    /// `@MainActor` because `HealthKitProviding` is main-actor isolated
+    /// (matches `HealthKitProvider`'s @Published vars). Call from
+    /// SwiftUI / other main-actor contexts directly; from a background
+    /// task, hop with `await MainActor.run { ... }`.
+    @MainActor
+    public static func compute(_ provider: HealthKitProviding) -> ReceptivityScore {
+        // ── 1. HR elevated, low motion → likely stressed ────────────
+        if let hr = provider.lastHR,
+           let baseline = provider.baselineHR,
+           hr > baseline * 1.15,
+           provider.motionState == .still || provider.motionState == .light
+        {
+            return ReceptivityScore(
+                score: -0.4,
+                confidence: 0.7,
+                reason: "HR up, you're sitting — likely stressed"
+            )
+        }
+
+        // ── 2. Low HRV (post-effort recovery) ───────────────────────
+        // SDNN drops sharply after exertion; the gate uses this to
+        // give a member a few minutes before pushing anything voice.
+        if let hrv = provider.lastHRV,
+           let baseline = provider.baselineHRV,
+           hrv < baseline * 0.7
+        {
+            return ReceptivityScore(
+                score: -0.3,
+                confidence: 0.6,
+                reason: "HRV low post-effort, give it a minute"
+            )
+        }
+
+        // ── 3. Calm baseline (HR + HRV both at rolling-7-day normal)
+        // Both must be present and within ±10 % of the member's own
+        // average. This is the only positive (interrupt-OK) branch.
+        if let hr = provider.lastHR,
+           let hrBaseline = provider.baselineHR,
+           let hrv = provider.lastHRV,
+           let hrvBaseline = provider.baselineHRV,
+           withinTolerance(hr, of: hrBaseline, fraction: 0.10),
+           withinTolerance(hrv, of: hrvBaseline, fraction: 0.10)
+        {
+            return ReceptivityScore(
+                score: +0.2,
+                confidence: 0.5,
+                reason: "vitals at baseline"
+            )
+        }
+
+        // ── 4. Insufficient data → no opinion. The gate composes
+        // with behavioural / calendar signals when we say nothing.
+        return .unknown
+    }
+
+    /// Helper for the calm-baseline branch. `value` must lie within
+    /// `fraction` of `target` (relative, not absolute) on either side.
+    private static func withinTolerance(_ value: Double, of target: Double, fraction: Double) -> Bool {
+        guard target > 0 else { return false }
+        let delta = abs(value - target) / target
+        return delta <= fraction
+    }
+}

--- a/apps/ios/Sources/HMAN/Resources/Info.plist
+++ b/apps/ios/Sources/HMAN/Resources/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+		Member-facing usage strings. iOS surfaces these verbatim in
+		the HealthKit permission sheet, so they need to be honest about
+		why HMAN reads each value and what stays on the device.
+
+		HMAN never writes to HealthKit, so NSHealthUpdateUsageDescription
+		is intentionally omitted. The matching capability lives in the
+		entitlements file (HealthKit, no Background Delivery yet).
+	-->
+	<key>NSHealthShareUsageDescription</key>
+	<string>HMAN reads your heart rate, heart-rate variability, recent motion, and last night's sleep so it can tell when you're stressed or recovering and avoid interrupting at a bad moment. Raw values stay on this device — only a coarse "interrupt OK" or "wait" hint is shared with the rest of HMAN.</string>
+</dict>
+</plist>

--- a/apps/ios/Sources/HMAN/Sensors/HealthKitProvider.swift
+++ b/apps/ios/Sources/HMAN/Sensors/HealthKitProvider.swift
@@ -1,0 +1,472 @@
+// HealthKitProvider.swift — autonomic-state sensor for the receptivity gate.
+//
+// Wraps `HKHealthStore` with a clean async surface tailored to what the
+// gate actually needs: a recent heart-rate value, an HRV (SDNN) sample,
+// a coarse motion classification, and a summary of last night's sleep.
+//
+// We deliberately keep the public API small and value-typed. The raw
+// `HKQuantitySample` / `HKCategorySample` instances stay inside this
+// file — callers never see them. That keeps the `(score, confidence,
+// reason)` tuple emitted by `HealthKitSignal` the only thing that
+// crosses module boundaries, satisfying the "no raw vitals leave the
+// phone" privacy guarantee from issue #16.
+//
+// Read-only. We never write to HealthKit. The matching Info.plist entry
+// is `NSHealthShareUsageDescription` only — `NSHealthUpdateUsageDescription`
+// is intentionally absent because HMAN doesn't need write capability.
+
+import Foundation
+#if canImport(HealthKit)
+import HealthKit
+#endif
+
+// ── Public value types ─────────────────────────────────────────────
+
+/// Coarse motion classification derived from the last 60 seconds of
+/// step count + active energy. The receptivity gate only needs a few
+/// buckets — actual workout / activity rings are out of scope (#16
+/// non-goals).
+public enum MotionState: String, Sendable, Equatable {
+    /// No detectable steps and negligible active energy.
+    case still
+    /// Some movement (walking around a room, fidgeting at a desk).
+    case light
+    /// Sustained movement (walk / commute).
+    case active
+    /// HealthKit unavailable or permission denied.
+    case unknown
+}
+
+/// Summary of the most recent in-bed period inferred from HealthKit's
+/// sleep-analysis category samples. We collapse the per-stage detail
+/// into the two numbers the gate cares about: total asleep duration
+/// and the rough quality bucket. Anything finer-grained is private.
+public struct SleepSummary: Sendable, Equatable {
+    /// Total time the member was asleep (any stage other than `inBed`
+    /// or `awake`). Seconds.
+    public let asleepSeconds: TimeInterval
+    /// Total in-bed time (informational; gate currently ignores).
+    public let inBedSeconds: TimeInterval
+    /// When the most recent sleep window ended. The gate uses this
+    /// to decide if the summary is fresh enough to act on.
+    public let endedAt: Date
+
+    public init(asleepSeconds: TimeInterval, inBedSeconds: TimeInterval, endedAt: Date) {
+        self.asleepSeconds = asleepSeconds
+        self.inBedSeconds = inBedSeconds
+        self.endedAt = endedAt
+    }
+}
+
+/// Errors surfaced by the provider. Authorisation refusals and a
+/// HealthKit-unavailable platform (i.e. iPad without the data store)
+/// share a single denied/unavailable case so callers can fall back to
+/// a behavioural-only receptivity score without branching on every
+/// error subtype.
+public enum HealthKitError: Error, Sendable, Equatable {
+    /// HealthKit not present on this device or `HKHealthStore.isHealthDataAvailable` returned false.
+    case unavailable
+    /// The member denied authorisation, or it hasn't been requested yet.
+    case notAuthorized
+    /// Underlying HealthKit query failed. `message` is `error.localizedDescription`.
+    case query(message: String)
+}
+
+// ── Provider protocol (so tests can stub) ──────────────────────────
+
+/// What `HealthKitSignal` actually consumes. Splitting this out from
+/// the concrete `HealthKitProvider` lets `HealthKitSignalTests` inject
+/// fixed values without touching `HKHealthStore` — which is impossible
+/// to use in `swift test` on a non-iOS host anyway.
+///
+/// `@MainActor` so the published properties on `HealthKitProvider`
+/// satisfy the requirements without nonisolated bridges. Tests run
+/// on the main actor (XCTest's default), so `StubProvider` is fine
+/// without extra ceremony.
+@MainActor
+public protocol HealthKitProviding: AnyObject {
+    /// Most recent heart-rate sample in beats-per-minute, or nil if no
+    /// recent sample is available.
+    var lastHR: Double? { get }
+    /// Most recent HRV (SDNN) sample in milliseconds.
+    var lastHRV: Double? { get }
+    /// Rolling motion classification from the last ~60 s.
+    var motionState: MotionState { get }
+    /// Last night's sleep summary, if HealthKit returned at least one
+    /// sleep sample within the last 24 hours.
+    var lastSleep: SleepSummary? { get }
+
+    /// Rolling 7-day baseline mean for HR (bpm) and HRV (ms). Used to
+    /// decide whether the current sample is "elevated" or "low" relative
+    /// to the member's own normal — never an absolute clinical threshold.
+    var baselineHR: Double? { get }
+    var baselineHRV: Double? { get }
+}
+
+// ── Concrete HealthKit-backed provider ─────────────────────────────
+
+/// Default `HealthKitProviding` implementation. On platforms where
+/// HealthKit isn't compiled in (e.g. running `swift test` on Linux CI)
+/// the stored properties stay nil and `requestAuthorization()` throws
+/// `.unavailable`.
+@MainActor
+public final class HealthKitProvider: ObservableObject, HealthKitProviding {
+    // ObservableObject so SwiftUI views can react to the latest reading
+    // without us having to invent a Combine pipeline. Explicitly
+    // `@Published` rather than @Observable so we keep the iOS 17 floor.
+
+    @Published public private(set) var lastHR: Double?
+    @Published public private(set) var lastHRV: Double?
+    @Published public private(set) var motionState: MotionState = .unknown
+    @Published public private(set) var lastSleep: SleepSummary?
+    @Published public private(set) var baselineHR: Double?
+    @Published public private(set) var baselineHRV: Double?
+
+    /// How often `start()` polls HealthKit. Default 60 s — HealthKit
+    /// reads are cheap but not free, and the gate only reconsiders
+    /// state that often. Configurable for tests / debugging.
+    public let pollInterval: TimeInterval
+
+    #if canImport(HealthKit)
+    private let store = HKHealthStore()
+    private var pollTask: Task<Void, Never>?
+    #endif
+
+    public init(pollInterval: TimeInterval = 60) {
+        self.pollInterval = pollInterval
+    }
+
+    deinit {
+        #if canImport(HealthKit)
+        pollTask?.cancel()
+        #endif
+    }
+
+    // ── Authorisation ───────────────────────────────────────────────
+
+    /// Request read-only authorisation for the four sample types we
+    /// rely on. Idempotent — iOS only prompts the member once per
+    /// (app, type) tuple even if this is called repeatedly.
+    public func requestAuthorization() async throws {
+        #if canImport(HealthKit)
+        guard HKHealthStore.isHealthDataAvailable() else {
+            throw HealthKitError.unavailable
+        }
+        let read: Set<HKObjectType> = [
+            HKObjectType.quantityType(forIdentifier: .heartRate)!,
+            HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
+            HKObjectType.quantityType(forIdentifier: .stepCount)!,
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!,
+        ]
+        // toShare: empty — strictly read-only.
+        try await store.requestAuthorization(toShare: [], read: read)
+        #else
+        throw HealthKitError.unavailable
+        #endif
+    }
+
+    // ── Polling lifecycle ───────────────────────────────────────────
+
+    /// Begin polling. Cancels any previous poll task and refreshes
+    /// every `pollInterval` seconds. Errors per cycle are swallowed
+    /// (logged via os_log in a future PR) — a single failed read
+    /// shouldn't tear down the whole stream.
+    public func start() {
+        #if canImport(HealthKit)
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.refresh()
+                try? await Task.sleep(nanoseconds: UInt64(self.pollInterval * 1_000_000_000))
+            }
+        }
+        #endif
+    }
+
+    /// Stop polling. Safe to call from `onDisappear`.
+    public func stop() {
+        #if canImport(HealthKit)
+        pollTask?.cancel()
+        pollTask = nil
+        #endif
+    }
+
+    /// Force a single refresh outside the polling loop. Useful after
+    /// `requestAuthorization()` returns so the first reading lands
+    /// before `pollInterval` elapses.
+    public func refresh() async {
+        #if canImport(HealthKit)
+        async let hr = (try? currentHR()) ?? nil
+        async let hrv = (try? recentHRV()) ?? nil
+        async let motion = (try? motionStateNow()) ?? .unknown
+        async let sleep = (try? sleepLastNight()) ?? nil
+        async let bHR = (try? baselineHRMean()) ?? nil
+        async let bHRV = (try? baselineHRVMean()) ?? nil
+
+        let resolvedHR = await hr
+        let resolvedHRV = await hrv
+        let resolvedMotion = await motion
+        let resolvedSleep = await sleep
+        let resolvedBaselineHR = await bHR
+        let resolvedBaselineHRV = await bHRV
+
+        self.lastHR = resolvedHR
+        self.lastHRV = resolvedHRV
+        self.motionState = resolvedMotion
+        self.lastSleep = resolvedSleep
+        self.baselineHR = resolvedBaselineHR
+        self.baselineHRV = resolvedBaselineHRV
+        #endif
+    }
+
+    // ── Single-shot reads ───────────────────────────────────────────
+
+    /// The most recent heart-rate sample, regardless of source. We
+    /// don't filter by `HKDevice` because Apple Watch / paired
+    /// chest-strap / Fitness+ all produce useful values for receptivity.
+    public func currentHR() async throws -> Double? {
+        #if canImport(HealthKit)
+        try await mostRecentQuantity(
+            type: .heartRate,
+            unit: HKUnit.count().unitDivided(by: .minute())
+        )
+        #else
+        throw HealthKitError.unavailable
+        #endif
+    }
+
+    /// HRV (SDNN) sample from the last five minutes, expressed in
+    /// milliseconds. HealthKit only logs SDNN when the watch detects
+    /// a quiet enough sample window, so this is often nil — the gate
+    /// must handle that gracefully.
+    public func recentHRV() async throws -> Double? {
+        #if canImport(HealthKit)
+        let now = Date()
+        let fiveMinAgo = now.addingTimeInterval(-5 * 60)
+        return try await mostRecentQuantity(
+            type: .heartRateVariabilitySDNN,
+            unit: HKUnit.secondUnit(with: .milli),
+            after: fiveMinAgo
+        )
+        #else
+        throw HealthKitError.unavailable
+        #endif
+    }
+
+    /// Motion classification from the last 60 s of step count + active
+    /// energy. This is intentionally coarse — finer motion fusion
+    /// belongs in #14 (CoreMotion / AirPods telemetry).
+    public func motionStateNow() async throws -> MotionState {
+        #if canImport(HealthKit)
+        let now = Date()
+        let oneMinAgo = now.addingTimeInterval(-60)
+        let steps = try await sumQuantity(
+            type: .stepCount,
+            unit: .count(),
+            from: oneMinAgo,
+            to: now
+        ) ?? 0
+        let kcal = try await sumQuantity(
+            type: .activeEnergyBurned,
+            unit: .kilocalorie(),
+            from: oneMinAgo,
+            to: now
+        ) ?? 0
+
+        // Thresholds chosen for "sitting at a desk" vs "walking
+        // around" vs "going somewhere" — not for clinical accuracy.
+        switch (steps, kcal) {
+        case (0, ..<0.3):
+            return .still
+        case (..<20, _), (_, ..<2.0):
+            return .light
+        default:
+            return .active
+        }
+        #else
+        return .unknown
+        #endif
+    }
+
+    /// Summary of the most recent sleep window in the last 24 hours.
+    /// Returns nil if no sleep samples are recorded — common for
+    /// members who don't wear a watch overnight.
+    public func sleepLastNight() async throws -> SleepSummary? {
+        #if canImport(HealthKit)
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
+            return nil
+        }
+        let now = Date()
+        let yesterday = now.addingTimeInterval(-24 * 60 * 60)
+        let predicate = HKQuery.predicateForSamples(withStart: yesterday, end: now, options: [])
+        let samples = try await fetchCategorySamples(type: sleepType, predicate: predicate)
+        guard !samples.isEmpty else { return nil }
+
+        var asleep: TimeInterval = 0
+        var inBed: TimeInterval = 0
+        var endedAt = Date.distantPast
+
+        for sample in samples {
+            let duration = sample.endDate.timeIntervalSince(sample.startDate)
+            if sample.endDate > endedAt { endedAt = sample.endDate }
+
+            switch HKCategoryValueSleepAnalysis(rawValue: sample.value) {
+            case .inBed:
+                inBed += duration
+            case .asleepUnspecified, .asleepCore, .asleepDeep, .asleepREM:
+                asleep += duration
+            case .awake, .none:
+                break
+            @unknown default:
+                break
+            }
+        }
+
+        guard endedAt > .distantPast else { return nil }
+        return SleepSummary(asleepSeconds: asleep, inBedSeconds: inBed, endedAt: endedAt)
+        #else
+        return nil
+        #endif
+    }
+
+    /// Rolling 7-day mean for HR. The gate calls this "baseline" — a
+    /// per-member normal we compare current samples against. Falls
+    /// back to nil when fewer than ~24 samples are present (i.e. a
+    /// brand-new install with no historical data).
+    public func baselineHRMean() async throws -> Double? {
+        #if canImport(HealthKit)
+        try await rollingSevenDayMean(
+            type: .heartRate,
+            unit: HKUnit.count().unitDivided(by: .minute())
+        )
+        #else
+        throw HealthKitError.unavailable
+        #endif
+    }
+
+    /// Rolling 7-day mean for HRV (SDNN, ms). Same caveats as
+    /// `baselineHRMean`.
+    public func baselineHRVMean() async throws -> Double? {
+        #if canImport(HealthKit)
+        try await rollingSevenDayMean(
+            type: .heartRateVariabilitySDNN,
+            unit: HKUnit.secondUnit(with: .milli)
+        )
+        #else
+        throw HealthKitError.unavailable
+        #endif
+    }
+
+    // ── HealthKit query helpers ────────────────────────────────────
+
+    #if canImport(HealthKit)
+    private func mostRecentQuantity(
+        type identifier: HKQuantityTypeIdentifier,
+        unit: HKUnit,
+        after: Date? = nil
+    ) async throws -> Double? {
+        guard let qty = HKObjectType.quantityType(forIdentifier: identifier) else {
+            return nil
+        }
+        let predicate = after.map {
+            HKQuery.predicateForSamples(withStart: $0, end: nil, options: [])
+        }
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        return try await withCheckedThrowingContinuation { cont in
+            let q = HKSampleQuery(
+                sampleType: qty,
+                predicate: predicate,
+                limit: 1,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    cont.resume(throwing: HealthKitError.query(message: error.localizedDescription))
+                    return
+                }
+                let value = (samples?.first as? HKQuantitySample)?.quantity.doubleValue(for: unit)
+                cont.resume(returning: value)
+            }
+            store.execute(q)
+        }
+    }
+
+    private func sumQuantity(
+        type identifier: HKQuantityTypeIdentifier,
+        unit: HKUnit,
+        from: Date,
+        to: Date
+    ) async throws -> Double? {
+        guard let qty = HKObjectType.quantityType(forIdentifier: identifier) else {
+            return nil
+        }
+        let predicate = HKQuery.predicateForSamples(withStart: from, end: to, options: [.strictStartDate])
+        return try await withCheckedThrowingContinuation { cont in
+            let q = HKStatisticsQuery(
+                quantityType: qty,
+                quantitySamplePredicate: predicate,
+                options: .cumulativeSum
+            ) { _, stats, error in
+                if let error {
+                    cont.resume(throwing: HealthKitError.query(message: error.localizedDescription))
+                    return
+                }
+                let value = stats?.sumQuantity()?.doubleValue(for: unit)
+                cont.resume(returning: value)
+            }
+            store.execute(q)
+        }
+    }
+
+    private func rollingSevenDayMean(
+        type identifier: HKQuantityTypeIdentifier,
+        unit: HKUnit
+    ) async throws -> Double? {
+        guard let qty = HKObjectType.quantityType(forIdentifier: identifier) else {
+            return nil
+        }
+        let now = Date()
+        let weekAgo = now.addingTimeInterval(-7 * 24 * 60 * 60)
+        let predicate = HKQuery.predicateForSamples(withStart: weekAgo, end: now, options: [])
+        return try await withCheckedThrowingContinuation { cont in
+            let q = HKStatisticsQuery(
+                quantityType: qty,
+                quantitySamplePredicate: predicate,
+                options: .discreteAverage
+            ) { _, stats, error in
+                if let error {
+                    cont.resume(throwing: HealthKitError.query(message: error.localizedDescription))
+                    return
+                }
+                let value = stats?.averageQuantity()?.doubleValue(for: unit)
+                cont.resume(returning: value)
+            }
+            store.execute(q)
+        }
+    }
+
+    private func fetchCategorySamples(
+        type: HKCategoryType,
+        predicate: NSPredicate
+    ) async throws -> [HKCategorySample] {
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: true)
+        return try await withCheckedThrowingContinuation { cont in
+            let q = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    cont.resume(throwing: HealthKitError.query(message: error.localizedDescription))
+                    return
+                }
+                cont.resume(returning: (samples as? [HKCategorySample]) ?? [])
+            }
+            store.execute(q)
+        }
+    }
+    #endif
+}

--- a/apps/ios/Tests/HMANTests/HealthKitSignalTests.swift
+++ b/apps/ios/Tests/HMANTests/HealthKitSignalTests.swift
@@ -1,0 +1,174 @@
+// HealthKitSignalTests.swift — exhaustive coverage of the four
+// heuristic branches in HealthKitSignal.compute.
+//
+// We don't touch HKHealthStore here; the protocol-based provider
+// `HealthKitProviding` lets us hand the adapter a fully-stubbed
+// snapshot of vitals. That's deliberate — `swift test` runs on
+// macos-14 in CI without a HealthKit host, and even on a real
+// simulator HealthKit refuses to return values to unsigned binaries.
+
+import XCTest
+@testable import HMAN
+
+@MainActor
+final class HealthKitSignalTests: XCTestCase {
+    // ── Branch 1: HR elevated, low motion → stressed ──────────────
+
+    func testHRElevatedLowMotionScoresStressed() {
+        let provider = StubProvider(
+            lastHR: 90,           // 90 bpm
+            lastHRV: 50,
+            motionState: .still,
+            baselineHR: 70,        // 90 / 70 = 1.29 → above 1.15 threshold
+            baselineHRV: 50
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result.score, -0.4, accuracy: 0.001)
+        XCTAssertEqual(result.confidence, 0.7, accuracy: 0.001)
+        XCTAssertEqual(result.reason, "HR up, you're sitting — likely stressed")
+    }
+
+    func testHRElevatedWithLightMotionAlsoCountsAsStressed() {
+        // Light fidget at the desk still counts — we only exclude
+        // sustained activity, where elevated HR is mechanical.
+        let provider = StubProvider(
+            lastHR: 95,
+            lastHRV: 45,
+            motionState: .light,
+            baselineHR: 70,
+            baselineHRV: 50
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result.score, -0.4, accuracy: 0.001)
+        XCTAssertEqual(result.reason, "HR up, you're sitting — likely stressed")
+    }
+
+    func testHRElevatedDuringActivityDoesNotTriggerStressed() {
+        // Walking around → elevated HR is just exertion, not stress.
+        // Should fall through to a different branch (or unknown).
+        let provider = StubProvider(
+            lastHR: 110,
+            lastHRV: nil,         // no HRV → can't trigger recovery branch
+            motionState: .active,
+            baselineHR: 70,
+            baselineHRV: nil
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result, ReceptivityScore.unknown)
+    }
+
+    // ── Branch 2: Low HRV (post-effort recovery) ──────────────────
+
+    func testLowHRVScoresRecovery() {
+        // HRV at 60% of baseline → well under the 0.7 threshold.
+        // HR not elevated, so branch 1 doesn't shadow this one.
+        let provider = StubProvider(
+            lastHR: 70,
+            lastHRV: 30,
+            motionState: .still,
+            baselineHR: 70,
+            baselineHRV: 50       // 30 / 50 = 0.6 < 0.7
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result.score, -0.3, accuracy: 0.001)
+        XCTAssertEqual(result.confidence, 0.6, accuracy: 0.001)
+        XCTAssertEqual(result.reason, "HRV low post-effort, give it a minute")
+    }
+
+    // ── Branch 3: Calm baseline ────────────────────────────────────
+
+    func testVitalsAtBaselineScoresCalm() {
+        // HR and HRV both within ±10 % of the rolling baseline.
+        let provider = StubProvider(
+            lastHR: 72,            // 72 / 70 = 1.029 → within 10 %
+            lastHRV: 48,           // 48 / 50 = 0.96 → within 10 %
+            motionState: .still,
+            baselineHR: 70,
+            baselineHRV: 50
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result.score, 0.2, accuracy: 0.001)
+        XCTAssertEqual(result.confidence, 0.5, accuracy: 0.001)
+        XCTAssertEqual(result.reason, "vitals at baseline")
+    }
+
+    func testVitalsJustOutsideBaselineDoNotScoreCalm() {
+        // HR 12 % above baseline → outside the ±10 % calm window,
+        // but still under the 15 % "stressed" threshold from branch 1.
+        // Should fall through to .unknown.
+        let provider = StubProvider(
+            lastHR: 78.4,          // 78.4 / 70 = 1.12 → outside ±10 %, under 1.15
+            lastHRV: 49,           // within ±10 %
+            motionState: .still,
+            baselineHR: 70,
+            baselineHRV: 50
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result, ReceptivityScore.unknown)
+    }
+
+    // ── Branch 4: insufficient data → unknown ──────────────────────
+
+    func testNoDataReturnsUnknown() {
+        let provider = StubProvider()  // all nil, motion .unknown
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result, ReceptivityScore.unknown)
+        XCTAssertEqual(result.confidence, 0.0)
+    }
+
+    func testHRWithoutBaselineReturnsUnknown() {
+        // First-run installs have no rolling baseline yet; we should
+        // refuse to act on a single sample without context.
+        let provider = StubProvider(
+            lastHR: 95,
+            lastHRV: nil,
+            motionState: .still,
+            baselineHR: nil,
+            baselineHRV: nil
+        )
+        let result = HealthKitSignal.compute(provider)
+        XCTAssertEqual(result, ReceptivityScore.unknown)
+    }
+
+    // ── ReceptivityScore clamping ──────────────────────────────────
+
+    func testScoreClampedToValidRange() {
+        let high = ReceptivityScore(score: 5.0, confidence: 2.0, reason: "x")
+        XCTAssertEqual(high.score, 1.0)
+        XCTAssertEqual(high.confidence, 1.0)
+
+        let low = ReceptivityScore(score: -5.0, confidence: -1.0, reason: "x")
+        XCTAssertEqual(low.score, -1.0)
+        XCTAssertEqual(low.confidence, 0.0)
+    }
+}
+
+// ── Stub provider ──────────────────────────────────────────────────
+
+/// In-memory `HealthKitProviding` for unit tests. No HealthKit calls,
+/// no async — just a snapshot of values the adapter consumes.
+@MainActor
+private final class StubProvider: HealthKitProviding {
+    var lastHR: Double?
+    var lastHRV: Double?
+    var motionState: MotionState
+    var lastSleep: SleepSummary?
+    var baselineHR: Double?
+    var baselineHRV: Double?
+
+    init(
+        lastHR: Double? = nil,
+        lastHRV: Double? = nil,
+        motionState: MotionState = .unknown,
+        lastSleep: SleepSummary? = nil,
+        baselineHR: Double? = nil,
+        baselineHRV: Double? = nil
+    ) {
+        self.lastHR = lastHR
+        self.lastHRV = lastHRV
+        self.motionState = motionState
+        self.lastSleep = lastSleep
+        self.baselineHR = baselineHR
+        self.baselineHRV = baselineHRV
+    }
+}


### PR DESCRIPTION
Replaces auto-closed #31 (its base branch `claude/issue-13-ios-skeleton` was deleted post-#28 squash-merge). Rebased onto current main. Same content.

Fixes #16.